### PR TITLE
Replaces weather-react-icons with lucide-react

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Automerge Dependabot PR
-        uses: eetu/action-automerge@v1
+        uses: eetu/action-automerge@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/components/OpenWeather.tsx
+++ b/components/OpenWeather.tsx
@@ -1,13 +1,11 @@
-import "weather-react-icons/lib/css/weather-icons.css";
-
 import { useTheme } from "@emotion/react";
 import { format } from "date-fns";
 import { fi } from "date-fns/locale/fi";
 import useSWR from "swr";
-import { WeatherIcon } from "weather-react-icons";
 
 import { fetcher } from "../pages";
 import { OpenWeatherReponse } from "../pages/api/weather/owm";
+import { getOwmWeatherIcon } from "../src/weatherIcons";
 import Arrow from "./Arrow";
 import Box from "./Box";
 import Icon from "./Icon";
@@ -133,15 +131,19 @@ const OpenWeather: React.FC<WeatherProps> = ({ className }) => {
               }}
             >{`${Math.round(data.current.feels_like)}°`}</div>
           </div>
-          <WeatherIcon
-            css={{
-              marginLeft: "25px",
-              fontSize: "52px",
-              alignSelf: "center",
-            }}
-            iconId={weather.id}
-            name="owm"
-          />
+          {(() => {
+            const IconComponent = getOwmWeatherIcon(weather.id);
+            return (
+              // eslint-disable-next-line react-hooks/static-components
+              <IconComponent
+                css={{
+                  marginLeft: "25px",
+                  alignSelf: "center",
+                }}
+                size={52}
+              />
+            );
+          })()}
           <div
             css={{
               fontSize: "13px",

--- a/components/TomorrowWeather.tsx
+++ b/components/TomorrowWeather.tsx
@@ -1,50 +1,18 @@
-import "weather-react-icons/lib/css/weather-icons.css";
-
 import { useTheme } from "@emotion/react";
 import { format } from "date-fns";
 import { fi } from "date-fns/locale/fi";
 import useSWR from "swr";
-import { WeatherIcon } from "weather-react-icons";
 
 import { fetcher } from "../pages";
 import { TomorrowWeatherData } from "../pages/api/weather/tomorrow";
 import { getTemperatureSegments } from "../src/utils";
+import { getWeatherIcon } from "../src/weatherIcons";
 import Arrow from "./Arrow";
 import Box from "./Box";
 import Icon from "./Icon";
 import RaindropIcon from "./RaindropIcon";
 import Tooltip from "./Tooltip";
 import WeatherChart from "./WeatherChart";
-
-// Tomorrow weather code to owm weather id
-const weatherCodeMap: { [key: number]: number } = {
-  1000: 800,
-  1100: 801,
-  1101: 802,
-  1102: 803,
-  1001: 804,
-  2000: 741,
-  2100: 701,
-  3000: 771,
-  3001: 771,
-  3002: 771,
-  4000: 300,
-  4001: 501,
-  4200: 500,
-  4201: 502,
-  5000: 601,
-  5001: 621,
-  5100: 600,
-  5101: 602,
-  6000: 611,
-  6001: 511,
-  6200: 615,
-  6201: 616,
-  7000: 611,
-  7101: 611,
-  7102: 611,
-  8000: 200,
-};
 
 const weatherCode: Record<number, string> = {
   1000: "Selkeä, Aurinkoinen",
@@ -110,7 +78,6 @@ const TomorrowWeather: React.FC<TomorrowWeatherProps> = ({ className }) => {
     return null;
   }
 
-  const iconId = weatherCodeMap[weather.values.weatherCode];
   const title = weatherCode[weather.values.weatherCode];
 
   return (
@@ -194,15 +161,19 @@ const TomorrowWeather: React.FC<TomorrowWeatherProps> = ({ className }) => {
               }}
             >{`${Math.round(weather.values.temperatureApparent)}°`}</div>
           </div>
-          <WeatherIcon
-            css={{
-              marginLeft: "25px",
-              fontSize: "52px",
-              alignSelf: "center",
-            }}
-            iconId={iconId}
-            name="owm"
-          />
+          {(() => {
+            const IconComponent = getWeatherIcon(weather.values.weatherCode);
+            return (
+              // eslint-disable-next-line react-hooks/static-components
+              <IconComponent
+                css={{
+                  marginLeft: "25px",
+                  alignSelf: "center",
+                }}
+                size={52}
+              />
+            );
+          })()}
           <div
             css={{
               fontSize: "13px",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.3",
     "envalid": "^8.1.1",
+    "lucide-react": "^0.553.0",
     "next": "16.0.1",
     "node-hue-api": "^5.0.0-beta.16",
     "react": "19.2.0",
@@ -26,8 +27,7 @@
     "react-dom": "19.2.0",
     "swr": "^2.3.6",
     "ts-node": "^10.9.2",
-    "usehooks-ts": "^3.1.1",
-    "weather-react-icons": "^4.0.2"
+    "usehooks-ts": "^3.1.1"
   },
   "devDependencies": {
     "@types/node": "24.10.0",

--- a/src/weatherIcons.tsx
+++ b/src/weatherIcons.tsx
@@ -1,0 +1,163 @@
+import {
+  Cloud,
+  CloudDrizzle,
+  CloudFog,
+  CloudHail,
+  CloudRain,
+  CloudSnow,
+  CloudSun,
+  Cloudy,
+  type LucideIcon,
+  Moon,
+  Snowflake,
+  Sun,
+  Zap,
+} from "lucide-react";
+
+type WeatherIconMapping = {
+  icon: LucideIcon;
+  description: string;
+};
+
+// Map OpenWeatherMap weather IDs to Lucide icons
+export const owmWeatherIconMap: Record<number, WeatherIconMapping> = {
+  // Thunderstorm (200-232)
+  200: { icon: Zap, description: "Thunderstorm with light rain" },
+  201: { icon: Zap, description: "Thunderstorm with rain" },
+  202: { icon: Zap, description: "Thunderstorm with heavy rain" },
+  210: { icon: Zap, description: "Light thunderstorm" },
+  211: { icon: Zap, description: "Thunderstorm" },
+  212: { icon: Zap, description: "Heavy thunderstorm" },
+  221: { icon: Zap, description: "Ragged thunderstorm" },
+  230: { icon: Zap, description: "Thunderstorm with light drizzle" },
+  231: { icon: Zap, description: "Thunderstorm with drizzle" },
+  232: { icon: Zap, description: "Thunderstorm with heavy drizzle" },
+
+  // Drizzle (300-321)
+  300: { icon: CloudDrizzle, description: "Light drizzle" },
+  301: { icon: CloudDrizzle, description: "Drizzle" },
+  302: { icon: CloudDrizzle, description: "Heavy drizzle" },
+  310: { icon: CloudDrizzle, description: "Light drizzle rain" },
+  311: { icon: CloudDrizzle, description: "Drizzle rain" },
+  312: { icon: CloudDrizzle, description: "Heavy drizzle rain" },
+  313: { icon: CloudDrizzle, description: "Shower rain and drizzle" },
+  314: { icon: CloudDrizzle, description: "Heavy shower rain and drizzle" },
+  321: { icon: CloudDrizzle, description: "Shower drizzle" },
+
+  // Rain (500-531)
+  500: { icon: CloudDrizzle, description: "Light rain" },
+  501: { icon: CloudRain, description: "Moderate rain" },
+  502: { icon: CloudRain, description: "Heavy rain" },
+  503: { icon: CloudRain, description: "Very heavy rain" },
+  504: { icon: CloudRain, description: "Extreme rain" },
+  511: { icon: CloudRain, description: "Freezing rain" },
+  520: { icon: CloudRain, description: "Light shower rain" },
+  521: { icon: CloudRain, description: "Shower rain" },
+  522: { icon: CloudRain, description: "Heavy shower rain" },
+  531: { icon: CloudRain, description: "Ragged shower rain" },
+
+  // Snow (600-622)
+  600: { icon: CloudSnow, description: "Light snow" },
+  601: { icon: CloudSnow, description: "Snow" },
+  602: { icon: CloudSnow, description: "Heavy snow" },
+  611: { icon: CloudHail, description: "Sleet" },
+  612: { icon: CloudHail, description: "Light shower sleet" },
+  613: { icon: CloudHail, description: "Shower sleet" },
+  615: { icon: CloudSnow, description: "Light rain and snow" },
+  616: { icon: CloudSnow, description: "Rain and snow" },
+  620: { icon: Snowflake, description: "Light shower snow" },
+  621: { icon: Snowflake, description: "Shower snow" },
+  622: { icon: CloudSnow, description: "Heavy shower snow" },
+
+  // Atmosphere (700-781)
+  701: { icon: CloudFog, description: "Mist" },
+  711: { icon: CloudFog, description: "Smoke" },
+  721: { icon: CloudFog, description: "Haze" },
+  731: { icon: CloudFog, description: "Dust" },
+  741: { icon: CloudFog, description: "Fog" },
+  751: { icon: CloudFog, description: "Sand" },
+  761: { icon: CloudFog, description: "Dust" },
+  762: { icon: CloudFog, description: "Volcanic ash" },
+  771: { icon: Cloud, description: "Squalls" },
+  781: { icon: Cloud, description: "Tornado" },
+
+  // Clear (800)
+  800: { icon: Sun, description: "Clear sky" },
+
+  // Clouds (801-804)
+  801: { icon: CloudSun, description: "Few clouds" },
+  802: { icon: CloudSun, description: "Scattered clouds" },
+  803: { icon: Cloudy, description: "Broken clouds" },
+  804: { icon: Cloud, description: "Overcast clouds" },
+};
+
+// Map Tomorrow.io weather codes to Lucide icons
+export const weatherIconMap: Record<number, WeatherIconMapping> = {
+  // Clear/Sunny
+  0: { icon: Sun, description: "Unknown" },
+  1000: { icon: Sun, description: "Clear, Sunny" },
+  1100: { icon: CloudSun, description: "Mostly Clear" },
+  1101: { icon: CloudSun, description: "Partly Cloudy" },
+  1102: { icon: Cloudy, description: "Mostly Cloudy" },
+  1001: { icon: Cloud, description: "Cloudy" },
+
+  // Fog
+  2000: { icon: CloudFog, description: "Fog" },
+  2100: { icon: CloudFog, description: "Light Fog" },
+
+  // Drizzle/Rain
+  4000: { icon: CloudDrizzle, description: "Drizzle" },
+  4001: { icon: CloudRain, description: "Rain" },
+  4200: { icon: CloudDrizzle, description: "Light Rain" },
+  4201: { icon: CloudRain, description: "Heavy Rain" },
+
+  // Snow
+  5000: { icon: CloudSnow, description: "Snow" },
+  5001: { icon: Snowflake, description: "Flurries" },
+  5100: { icon: CloudSnow, description: "Light Snow" },
+  5101: { icon: CloudSnow, description: "Heavy Snow" },
+
+  // Freezing Rain
+  6000: { icon: CloudRain, description: "Freezing Drizzle" },
+  6001: { icon: CloudRain, description: "Freezing Rain" },
+  6200: { icon: CloudDrizzle, description: "Light Freezing Rain" },
+  6201: { icon: CloudRain, description: "Heavy Freezing Rain" },
+
+  // Ice Pellets
+  7000: { icon: CloudHail, description: "Ice Pellets" },
+  7101: { icon: CloudHail, description: "Heavy Ice Pellets" },
+  7102: { icon: CloudHail, description: "Light Ice Pellets" },
+
+  // Thunderstorm
+  8000: { icon: Zap, description: "Thunderstorm" },
+};
+
+// Get the appropriate icon for OpenWeatherMap weather ID
+export const getOwmWeatherIcon = (weatherId: number): LucideIcon => {
+  const mapping = owmWeatherIconMap[weatherId];
+  return mapping?.icon || Cloud; // Fallback icon
+};
+
+// Get the appropriate icon for Tomorrow.io weather code
+export const getWeatherIcon = (
+  weatherCode: number,
+  isNight?: boolean
+): LucideIcon => {
+  const mapping = weatherIconMap[weatherCode];
+
+  if (!mapping) {
+    return Cloud; // Fallback icon
+  }
+
+  // Use moon icon for clear conditions at night
+  if (isNight && (weatherCode === 1000 || weatherCode === 1100)) {
+    return Moon;
+  }
+
+  return mapping.icon;
+};
+
+// Get weather description for Tomorrow.io
+export const getWeatherDescription = (weatherCode: number): string => {
+  return weatherIconMap[weatherCode]?.description || "Unknown";
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3365,6 +3365,7 @@ __metadata:
     eslint-config-prettier: "npm:10.1.8"
     eslint-plugin-simple-import-sort: "npm:12.1.1"
     eslint-plugin-unused-imports: "npm:4.3.0"
+    lucide-react: "npm:^0.553.0"
     next: "npm:16.0.1"
     node-hue-api: "npm:^5.0.0-beta.16"
     prettier: "npm:3.6.2"
@@ -3376,7 +3377,6 @@ __metadata:
     ts-node: "npm:^10.9.2"
     typescript: "npm:5.9.3"
     usehooks-ts: "npm:^3.1.1"
-    weather-react-icons: "npm:^4.0.2"
   languageName: unknown
   linkType: soft
 
@@ -4124,7 +4124,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -4141,6 +4141,15 @@ __metadata:
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10/951d2673dcc64a7fb888bf3d13bc2fdf923faca97d89cdb405ba3dfff77e2b26e5798d405e78fcd7094c9e7b8b4dab2ddc5a4f8a11928af24a207b7c738ca3f8
+  languageName: node
+  linkType: hard
+
+"lucide-react@npm:^0.553.0":
+  version: 0.553.0
+  resolution: "lucide-react@npm:0.553.0"
+  peerDependencies:
+    react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/741826c0b45b22213b902b5ff8236b226e9dd66403be45ac5e41fc448484ad6550bc39f8eb454dd0efcad2a2b4271b3eec8489493b6e42b96e39482f6abc64c4
   languageName: node
   linkType: hard
 
@@ -4681,19 +4690,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^17.0.1":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-    scheduler: "npm:^0.20.2"
-  peerDependencies:
-    react: 17.0.2
-  checksum: 10/0b3836131a64da8b1c2c852cc28b09c21a738c33c7a8d6021ac20d5619d753c8ee5fff8f97c95f2fc33053e44c2cbce9657453e21c55900164e6e0c3e955e826
-  languageName: node
-  linkType: hard
-
 "react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -4705,16 +4701,6 @@ __metadata:
   version: 19.2.0
   resolution: "react@npm:19.2.0"
   checksum: 10/e13bcdb8e994c3cfa922743cb75ca8deb60531bf02f584d2d8dab940a8132ce8a2e6ef16f8ed7f372b4072e7a7eeff589b2812dabbedfa73e6e46201dac8a9d0
-  languageName: node
-  linkType: hard
-
-"react@npm:^17.0.1":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-  checksum: 10/ece60c31c1d266d132783aaaffa185d2e4c9b4db144f853933ec690cee1e0600c8929a1dd0a9e79323eea8e2df636c9a06d40f6cfdc9f797f65225433e67f707
   languageName: node
   linkType: hard
 
@@ -5007,16 +4993,6 @@ __metadata:
     es-errors: "npm:^1.3.0"
     is-regex: "npm:^1.2.1"
   checksum: 10/ebdb61f305bf4756a5b023ad86067df5a11b26898573afe9e52a548a63c3bd594825d9b0e2dde2eb3c94e57e0e04ac9929d4107c394f7b8e56a4613bed46c69a
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-  checksum: 10/898917fa475386953d998add9107c04bf2c335eee86172833995dee126d12a68bee3c29edbd61fa0bcbcb8ee511c422eaab23b86b02f95aab26ecfaed8df5e64
   languageName: node
   linkType: hard
 
@@ -5939,24 +5915,6 @@ __metadata:
   version: 3.0.1
   resolution: "v8-compile-cache-lib@npm:3.0.1"
   checksum: 10/88d3423a52b6aaf1836be779cab12f7016d47ad8430dffba6edf766695e6d90ad4adaa3d8eeb512cc05924f3e246c4a4ca51e089dccf4402caa536b5e5be8961
-  languageName: node
-  linkType: hard
-
-"weather-icons@git+https://github.com/erikflowers/weather-icons.git":
-  version: 2.0.12
-  resolution: "weather-icons@https://github.com/erikflowers/weather-icons.git#commit=bb80982bf1f43f2d57f9dd753e7413bf88beb9ed"
-  checksum: 10/1b0109617d3af573aaaa25c0789accc6379c925aab0abd4d8b39277346a416cf0e5c8ebfdd51980a64de28e3b2d01a3dd78e9cf00e5dc247b2c0b3871fecf237
-  languageName: node
-  linkType: hard
-
-"weather-react-icons@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "weather-react-icons@npm:4.0.2"
-  dependencies:
-    react: "npm:^17.0.1"
-    react-dom: "npm:^17.0.1"
-    weather-icons: "git+https://github.com/erikflowers/weather-icons.git"
-  checksum: 10/792c96f09691d7ef0322e8b27f9be901e8f9b2d4d79669a0ddb32ce191c349042d86cd02e6d7e7f725e703aff3b373142ec530d2aee6f765f353612a8515fddb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Migrates from the `weather-react-icons` library to `lucide-react` for displaying weather icons.

This change improves icon rendering and maintainability by using a more modern and actively maintained icon library. It also removes the dependency on the external CSS file.