### PR TITLE
Add SolisCloud PV monitoring widget

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,3 +18,9 @@ HUE_ROOM_TYPES='{}'
 # Sensor history
 # HCC_DB_PATH=hcc.db
 # HCC_HISTORY_RETENTION_DAYS=90
+
+# SolisCloud PV monitoring
+SOLIS_KEY_ID=
+SOLIS_KEY_SECRET=
+SOLIS_STATION_ID=
+# SOLIS_BASE_URL=https://www.soliscloud.com:13333

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand",
- "sha1",
+ "sha1 0.10.6",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -385,6 +385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +474,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +546,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -537,6 +576,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -606,8 +654,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -903,14 +963,18 @@ dependencies = [
  "actix-files",
  "actix-web",
  "actix-web-lab",
+ "base64",
  "chrono",
  "dotenvy",
  "futures-util",
+ "hmac",
+ "md5",
  "quick-xml",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
+ "sha1 0.11.0",
  "sun",
  "thiserror",
  "tokio",
@@ -927,6 +991,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
+]
 
 [[package]]
 name = "http"
@@ -989,6 +1062,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1337,6 +1419,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
@@ -1920,8 +2008,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1931,8 +2030,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -24,6 +24,10 @@ rusqlite = { version = "0.34", features = ["bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
 quick-xml = "0.39"
 sun = "0.3"
+hmac = "0.13.0"
+sha1 = "0.11.0"
+md5 = "0.8.0"
+base64 = "0.22.1"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cache;
 pub mod hue;
 pub mod settings;
+pub mod solis;
 pub mod storage;
 pub mod weather;
 
@@ -23,6 +24,7 @@ pub struct AppState {
     pub hue_cache: Cache<hue::models::HueResponse>,
     pub tomorrow_cache: Cache<serde_json::Value>,
     pub weather_cache: Cache<weather::models::WeatherResponse>,
+    pub solis_cache: Cache<solis::models::SolisWidgetData>,
     pub hue_events_tx: broadcast::Sender<hue::events::HueLiveEvent>,
     pub storage: storage::Storage,
 }
@@ -36,6 +38,7 @@ pub struct AppState {
         hue::handlers::events_sse,
         hue::handlers::pair,
         hue::handlers::toggle_group,
+        solis::handlers::get_data,
         status,
         sensor_history,
     ),
@@ -48,6 +51,7 @@ pub struct AppState {
         hue::events::HueLiveEvent,
         hue::handlers::PairRequest,
         hue::handlers::PairResponse,
+        solis::models::SolisWidgetData,
         StatusResponse,
         storage::SensorReading,
     ))
@@ -179,6 +183,10 @@ pub fn create_app(
                             "/toggleGroup/{id}",
                             web::post().to(hue::handlers::toggle_group),
                         ),
+                )
+                .service(
+                    web::scope("/solis")
+                        .route("", web::get().to(solis::handlers::get_data)),
                 ),
         )
         .service(SwaggerUi::new("/docs/{_:.*}").url("/api-doc/openapi.json", openapi))
@@ -221,6 +229,7 @@ pub fn create_test_app_state_with(settings: Settings) -> Arc<AppState> {
         hue_cache: Cache::new(std::time::Duration::from_secs(3)),
         tomorrow_cache: Cache::new(std::time::Duration::from_secs(3600)),
         weather_cache: Cache::new(std::time::Duration::from_secs(3600)),
+        solis_cache: Cache::new(std::time::Duration::from_secs(300)),
         hue_events_tx,
         storage,
     })
@@ -258,6 +267,7 @@ pub async fn run_server() -> std::io::Result<()> {
         hue_cache: Cache::new(std::time::Duration::from_secs(3)),
         tomorrow_cache: Cache::new(std::time::Duration::from_secs(3600)),
         weather_cache: Cache::new(std::time::Duration::from_secs(3600)),
+        solis_cache: Cache::new(std::time::Duration::from_secs(300)),
         hue_events_tx: hue_events_tx.clone(),
         storage,
     });

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -11,6 +11,10 @@ pub struct Settings {
     pub static_dir: String,
     pub port: u16,
     pub history_retention_days: u32,
+    pub solis_key_id: String,
+    pub solis_key_secret: String,
+    pub solis_station_id: String,
+    pub solis_base_url: String,
 }
 
 impl Settings {
@@ -26,6 +30,10 @@ impl Settings {
             static_dir: "./dist".into(),
             port: 3000,
             history_retention_days: 0,
+            solis_key_id: String::new(),
+            solis_key_secret: String::new(),
+            solis_station_id: String::new(),
+            solis_base_url: "https://www.soliscloud.com:13333".into(),
         }
     }
 
@@ -53,6 +61,11 @@ impl Settings {
                 .ok()
                 .and_then(|d| d.parse().ok())
                 .unwrap_or(0),
+            solis_key_id: env::var("SOLIS_KEY_ID").unwrap_or_default(),
+            solis_key_secret: env::var("SOLIS_KEY_SECRET").unwrap_or_default(),
+            solis_station_id: env::var("SOLIS_STATION_ID").unwrap_or_default(),
+            solis_base_url: env::var("SOLIS_BASE_URL")
+                .unwrap_or_else(|_| "https://www.soliscloud.com:13333".into()),
         }
     }
 }

--- a/backend/src/solis/client.rs
+++ b/backend/src/solis/client.rs
@@ -1,0 +1,141 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
+use chrono::Utc;
+use hmac::{Hmac, KeyInit, Mac};
+use sha1::Sha1;
+
+use crate::AppState;
+
+use super::models::SolisWidgetData;
+
+const CONTENT_TYPE: &str = "application/json";
+
+#[derive(Debug, thiserror::Error)]
+pub enum SolisError {
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("API error {status}: {message}")]
+    Api { status: u16, message: String },
+    #[error("Missing field in response: {0}")]
+    MissingField(&'static str),
+}
+
+fn gmt_date() -> String {
+    Utc::now().format("%a, %d %b %Y %H:%M:%S GMT").to_string()
+}
+
+fn md5_base64(body: &str) -> String {
+    let digest = md5::compute(body.as_bytes());
+    STANDARD.encode(digest.as_ref())
+}
+
+fn hmac_sha1_base64(secret: &str, message: &str) -> String {
+    let mut mac = Hmac::<Sha1>::new_from_slice(secret.as_bytes())
+        .expect("HMAC accepts keys of any length");
+    mac.update(message.as_bytes());
+    STANDARD.encode(mac.finalize().into_bytes())
+}
+
+fn build_auth_headers(
+    key_id: &str,
+    key_secret: &str,
+    path: &str,
+    body: &str,
+) -> (String, String, String) {
+    let date = gmt_date();
+    let content_md5 = md5_base64(body);
+    let string_to_sign = format!("POST\n{content_md5}\n{CONTENT_TYPE}\n{date}\n{path}");
+    let sig = hmac_sha1_base64(key_secret, &string_to_sign);
+    let authorization = format!("API {key_id}:{sig}");
+
+    tracing::debug!(
+        body,
+        content_md5,
+        date,
+        path,
+        string_to_sign,
+        authorization,
+        "SolisCloud signing"
+    );
+
+    (date, content_md5, authorization)
+}
+
+pub async fn fetch_station_detail(state: &AppState) -> Result<SolisWidgetData, SolisError> {
+    let settings = &state.settings;
+    let path = "/v1/api/stationDetail";
+    let body = format!(r#"{{"id":"{}"}}"#, settings.solis_station_id);
+
+    let (date, content_md5, authorization) =
+        build_auth_headers(&settings.solis_key_id, &settings.solis_key_secret, path, &body);
+
+    let url = format!("{}{}", settings.solis_base_url, path);
+
+    let res = state
+        .http_client
+        .post(&url)
+        .header("Content-Type", CONTENT_TYPE)
+        .header("Date", &date)
+        .header("Content-MD5", &content_md5)
+        .header("Authorization", &authorization)
+        .body(body)
+        .send()
+        .await?;
+
+    let status = res.status().as_u16();
+    let json: serde_json::Value = res.json().await?;
+
+    if status != 200 {
+        let message = json
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown error")
+            .to_string();
+        return Err(SolisError::Api { status, message });
+    }
+
+    let code = json.get("code").and_then(|c| c.as_str()).unwrap_or("");
+    if code != "0" {
+        let message = json
+            .get("msg")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown error")
+            .to_string();
+        return Err(SolisError::Api { status: 200, message });
+    }
+
+    let data = json
+        .get("data")
+        .ok_or(SolisError::MissingField("data"))?;
+
+    Ok(SolisWidgetData {
+        power: data.get("power").and_then(|v| v.as_f64()).unwrap_or(0.0),
+        power_unit: string_field(data, "powerStr"),
+        today_energy: data.get("dayEnergy").and_then(|v| v.as_f64()).unwrap_or(0.0),
+        today_energy_unit: string_field(data, "dayEnergyStr"),
+        month_energy: data.get("monthEnergy").and_then(|v| v.as_f64()).unwrap_or(0.0),
+        month_energy_unit: string_field(data, "monthEnergyStr"),
+        year_energy: data.get("yearEnergy").and_then(|v| v.as_f64()).unwrap_or(0.0),
+        year_energy_unit: string_field(data, "yearEnergyStr"),
+        total_energy: data.get("allEnergy").and_then(|v| v.as_f64()).unwrap_or(0.0),
+        total_energy_unit: string_field(data, "allEnergyStr"),
+        grid_power: data.get("psum").and_then(|v| v.as_f64()),
+        grid_power_unit: data.get("psumStr").and_then(|v| v.as_str()).map(String::from),
+        battery_soc: data.get("batteryPercent").and_then(|v| v.as_f64()),
+        battery_power: data.get("batteryPower").and_then(|v| v.as_f64()),
+        battery_power_unit: data.get("batteryPowerStr").and_then(|v| v.as_str()).map(String::from),
+        status: data.get("state").and_then(|v| v.as_u64()).unwrap_or(2) as u8,
+        updated_at: data
+            .get("dataTimestamp")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<i64>().ok())
+            .or_else(|| data.get("dataTimestamp").and_then(|v| v.as_i64()))
+            .unwrap_or(0),
+    })
+}
+
+fn string_field(data: &serde_json::Value, key: &str) -> String {
+    data.get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}

--- a/backend/src/solis/handlers.rs
+++ b/backend/src/solis/handlers.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use actix_web::{web, HttpResponse};
+
+use crate::AppState;
+
+#[utoipa::path(
+    get,
+    path = "/api/solis",
+    responses(
+        (status = 200, description = "SolisCloud station widget data", body = super::models::SolisWidgetData),
+        (status = 502, description = "Failed to fetch data from SolisCloud"),
+        (status = 503, description = "SolisCloud not configured"),
+    )
+)]
+pub async fn get_data(state: web::Data<Arc<AppState>>) -> HttpResponse {
+    if state.settings.solis_key_id.is_empty() {
+        return HttpResponse::ServiceUnavailable()
+            .json(serde_json::json!({"error": "SolisCloud not configured"}));
+    }
+
+    if let Some(cached) = state.solis_cache.get("station").await {
+        tracing::debug!("Returning cached SolisCloud data");
+        return HttpResponse::Ok().json(cached);
+    }
+
+    match super::client::fetch_station_detail(&state).await {
+        Ok(data) => {
+            state.solis_cache.set("station".into(), data.clone()).await;
+            HttpResponse::Ok().json(data)
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch SolisCloud data: {e}");
+            if let Some(stale) = state.solis_cache.get_stale("station").await {
+                tracing::warn!("Returning stale SolisCloud data");
+                return HttpResponse::Ok().json(stale);
+            }
+            HttpResponse::BadGateway()
+                .json(serde_json::json!({"error": e.to_string()}))
+        }
+    }
+}

--- a/backend/src/solis/mod.rs
+++ b/backend/src/solis/mod.rs
@@ -1,0 +1,3 @@
+pub mod client;
+pub mod handlers;
+pub mod models;

--- a/backend/src/solis/models.rs
+++ b/backend/src/solis/models.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SolisWidgetData {
+    /// Current AC output power
+    pub power: f64,
+    pub power_unit: String,
+    /// Energy generated today
+    pub today_energy: f64,
+    pub today_energy_unit: String,
+    /// Energy generated this month
+    pub month_energy: f64,
+    pub month_energy_unit: String,
+    /// Energy generated this year
+    pub year_energy: f64,
+    pub year_energy_unit: String,
+    /// Total lifetime energy generated
+    pub total_energy: f64,
+    pub total_energy_unit: String,
+    /// Grid power: positive = exporting, negative = importing
+    pub grid_power: Option<f64>,
+    pub grid_power_unit: Option<String>,
+    /// Battery state of charge (%)
+    pub battery_soc: Option<f64>,
+    /// Battery power: positive = charging, negative = discharging
+    pub battery_power: Option<f64>,
+    pub battery_power_unit: Option<String>,
+    /// 1 = online, 2 = offline, 3 = alarm
+    pub status: u8,
+    /// Data timestamp from inverter (UTC+8 ms)
+    pub updated_at: i64,
+}

--- a/backend/tests/smoke.rs
+++ b/backend/tests/smoke.rs
@@ -50,6 +50,10 @@ fn test_settings_with_mock(mock_url: &str) -> Settings {
         static_dir: "./dist".into(),
         port: 3000,
         history_retention_days: 90,
+        solis_base_url: "".into(),
+        solis_key_id: "".into(),
+        solis_key_secret: "".into(),
+        solis_station_id: "".into(),
     }
 }
 

--- a/documentation/soliscloud-api.md
+++ b/documentation/soliscloud-api.md
@@ -1,0 +1,239 @@
+# SolisCloud Platform API Reference
+
+Version: V2.0.3  
+Base URL: `https://www.soliscloud.com:13333`  
+Credentials: stored as `SOLIS_KEY_ID` / `SOLIS_KEY_SECRET` secrets
+
+---
+
+## Authentication
+
+Every request is a **POST** with these headers:
+
+| Header | Value |
+|---|---|
+| `Content-Type` | `application/json` |
+| `Content-MD5` | Base64(MD5(raw JSON body)) |
+| `Date` | GMT string: `EEE, dd MMM yyyy HH:mm:ss 'GMT'` — day must be zero-padded (must be within ±15 min of server time) |
+| `Authorization` | `API {keyId}:{sign}` |
+
+**Sign formula:**
+```
+sign = Base64(HmacSHA1(keySecret,
+  "POST\n"
+  + Content-MD5 + "\n"
+  + "application/json\n"
+  + Date + "\n"
+  + CanonicalizedResource   // e.g. "/v1/api/stationDetail"
+))
+```
+
+**Response envelope:**
+```json
+{ "success": true, "code": "0", "msg": "success", "data": { ... } }
+```
+`code: "0"` = success. See Appendix 1 in the PDF for error codes.
+
+**Rate limit:** 2 requests/sec for all endpoints.  
+**Data refresh:** every 5 minutes.
+
+---
+
+## Recommended endpoints for dashboard
+
+### Priority 1 — main view (compact PV summary)
+
+#### `POST /v1/api/userStationList`
+List all power stations. Call once on load to get station IDs.
+
+Request:
+```json
+{ "pageNo": 1, "pageSize": 100 }
+```
+
+Key response fields per station record:
+| Field | Description |
+|---|---|
+| `id` | Station ID (needed for subsequent calls) |
+| `stationName` | Human-readable name |
+| `power` / `powerStr` | Current output power (e.g. `5.2 kW`) |
+| `dayEnergy` / `dayEnergyStr` | Today's generation (e.g. `12.4 kWh`) |
+| `monthEnergy` / `yearEnergy` | Monthly / yearly generation |
+| `allEnergy` / `allEnergyStr` | Lifetime generation |
+| `capacity` / `capacityStr` | Installed capacity |
+| `gridSellTodayEnergy` | Energy sold to grid today |
+| `gridPurchasedTodayEnergy` | Energy bought from grid today |
+| `batteryTodayChargeEnergy` | Battery charged today |
+| `batteryTodayDischargeEnergy` | Battery discharged today |
+| `homeLoadTodayEnergy` | Load consumption today |
+| `synchronizationType` | Grid mode: 0=full export, 1=self-use, 2=off-grid |
+| `stationTypeNew` | Plant type (see Appendix 2) |
+
+---
+
+#### `POST /v1/api/stationDetail`
+Full real-time details for a single station. Best endpoint for the main view widget.
+
+Request:
+```json
+{ "id": "<stationId>" }
+```
+
+Key response fields (superset of userStationList):
+| Field | Description |
+|---|---|
+| `power` / `powerStr` | Current AC output power |
+| `dayEnergy` / `dayEnergyStr` | Today's generation |
+| `monthEnergy` / `yearEnergy` / `allEnergy` | Period totals |
+| `psum` / `psumStr` | Total active power of grid |
+| `batteryPercent` | Battery SOC % |
+| `batteryPower` / `batteryPowerStr` | Battery power (+ = charging, - = discharging) |
+| `gridPurchasedDayEnergy` | Grid import today |
+| `gridSellDayEnergy` | Grid export today |
+| `homeLoadTodayEnergy` | Home load today |
+| `state` | Station status: 1=online, 2=offline, 3=alarm |
+| `dataTimestamp` | Last data update (UTC+8 timestamp) |
+| `sr` / `ss` | Sunrise / sunset times |
+| `condTxtD` / `tmpMax` / `tmpMin` | Weather info (daytime) |
+| `fullHour` | Peak sun hours today |
+| `powerStationAvoidedCo2` | CO₂ avoided (for environmental display) |
+
+---
+
+### Priority 2 — detail tab
+
+#### `POST /v1/api/inverterList`
+List inverters under the account (or under a specific station).
+
+Request:
+```json
+{ "pageNo": 1, "pageSize": 100, "stationId": "<stationId>" }
+```
+
+Key fields per inverter:
+| Field | Description |
+|---|---|
+| `id` / `sn` | Inverter ID and serial number |
+| `pac` / `pacStr` | Real-time AC output power |
+| `etoday` / `etodayStr` | Daily generation |
+| `etotal` / `etotalStr` | Total generation |
+| `state` | 1=online, 2=offline, 3=alarm |
+| `batteryCapacitySoc` | Battery SOC (if storage inverter) |
+| `batteryPower` | Battery power |
+| `gridPurchasedTodayEnergy` | Grid import today |
+| `gridSellTodayEnergy` | Grid export today |
+| `productModel` | `1`=grid-tie, `2`=storage |
+
+---
+
+#### `POST /v1/api/inverterDetail`
+Full real-time detail for one inverter including per-string DC data.
+
+Request:
+```json
+{ "id": "<inverterId>", "sn": "<inverterSN>" }
+```
+
+Key fields (all DC/AC per-channel data):
+| Field | Description |
+|---|---|
+| `pac` / `pacStr` | Real-time AC output |
+| `dcPac` / `dcPacStr` | Total DC input power |
+| `uPv1`…`uPv4` / `iPv1`…`iPv4` | DC voltage/current per string |
+| `pow1`…`pow4` | DC power per string (W) |
+| `uAc1`…`uAc3` / `iAc1`…`iAc3` | AC voltage/current per phase |
+| `fac` / `facStr` | Grid frequency (Hz) |
+| `eToday` / `eMonth` / `eYear` / `eTotal` | Energy by period |
+| `inverterTemperature` | Inverter temperature |
+| `batteryCapacitySoc` | Battery SOC |
+| `batteryPower` | Battery charge/discharge power |
+| `batteryVoltage` / `bstteryCurrent` | Battery V and A |
+| `batteryTodayChargeEnergy` / `batteryTodayDischargeEnergy` | Daily battery cycles |
+| `gridPurchasedTodayEnergy` / `gridSellTodayEnergy` | Grid import/export today |
+| `familyLoadPower` | Home load power |
+| `homeLoadTodayEnergy` | Home load energy today |
+| `powerFactor` | Power factor |
+| `reactivePower` / `apparentPower` | Reactive / apparent power |
+| `state` | 1=online, 2=offline, 3=alarm |
+| `dataTimestamp` | Last update (UTC+8 timestamp) |
+
+---
+
+#### `POST /v1/api/stationDay`
+5-minute interval data for a station on a given day. Use for power charts.
+
+Request:
+```json
+{
+  "id": "<stationId>",
+  "money": "EUR",
+  "time": "2026-04-21",
+  "timeZone": 2
+}
+```
+
+Returns array of records (one per 5-min interval):
+| Field | Description |
+|---|---|
+| `time` | Timestamp (ms) |
+| `timeStr` | Human time (e.g. `"14:25:00"`) |
+| `power` / `powerStr` | Station output power at that time |
+| `psum` | Grid power at that time |
+| `batteryPower` | Battery power at that time |
+| `familyLoadPower` | Load at that time |
+| `produceEnergy` | Cumulative production |
+| `consumeEnergy` | Cumulative consumption |
+
+---
+
+#### `POST /v1/api/stationMonth`
+Daily aggregates for a single station in a given month. Use for bar/area charts.
+
+Request:
+```json
+{
+  "id": "<stationId>",
+  "money": "EUR",
+  "time": "2026-04",
+  "timeZone": 2
+}
+```
+
+---
+
+## Suggested call sequence for dashboard
+
+```
+1. userStationList        → get stationId(s)
+2. stationDetail          → main view widget (current power, today/month/year totals)
+3. inverterList           → detail tab, list of inverters
+4. inverterDetail         → detail tab, per-inverter drill-down (DC strings, temps)
+5. stationDay             → power chart (today's generation curve, 5-min resolution)
+6. stationMonth           → monthly bar chart in detail tab
+```
+
+Polling cadence: every 5 minutes (matches API data refresh rate).
+
+---
+
+## Main view widget — recommended fields
+
+Compact display for the home screen:
+
+```
+PV Now:   pac / power          (e.g. "3.2 kW")
+Today:    dayEnergy             (e.g. "12.4 kWh")
+Grid:     psum                  (+ = exporting, - = importing)
+Battery:  batteryPercent + batteryPower   (if storage system)
+```
+
+---
+
+## Notes
+
+- All numeric values come with a paired `*Str` unit field — always use it for display.
+- `state` values: 1=online, 2=offline, 3=alarm (applies to both stations and inverters).
+- DC string fields (`uPv1`–`uPv32`, `iPv1`–`iPv32`, `pow1`–`pow32`) vary by inverter model; check `dcInputType` (value+1 = actual channel count).
+- `batteryPower` sign convention: positive = charging, negative = discharging (verify with your hardware).
+- `dataTimestamp` is UTC+8; convert to local time for display.
+- Date header must be within ±15 minutes of server time or the call fails.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Icon from "./components/Icon";
 import LightGroups from "./components/LightGroups";
 import LocationForm from "./components/LocationForm";
 import Motion from "./components/Motion";
+import SolisBox from "./components/SolisBox";
 import TemperatureBox from "./components/TemperatureBox";
 import { mq } from "./mq";
 import { type HueLiveEvent, type Response, type Sensor } from "./types/hue";
@@ -147,7 +148,7 @@ const App = () => {
       </button>
       <div
         css={{
-          width: 580,
+          width: 720,
           flexShrink: 0,
           [mq[0]]: {
             width: "100%",
@@ -215,7 +216,8 @@ const App = () => {
               flex: 1,
               minWidth: 0,
               display: "grid",
-              gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+              gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+              alignItems: "start",
               gap: 20,
               [mq[0]]: {
                 display: "flex",
@@ -227,7 +229,7 @@ const App = () => {
           >
             {view === "temperature" && (
               <>
-                <FmiWeatherBox css={{ gridColumn: "1 / span 3", gridRow: 1 }} />
+                <FmiWeatherBox css={{ gridColumn: "1 / span 4", gridRow: 1 }} />
                 <TemperatureBox
                   css={temperatureCss}
                   sensors={outside}
@@ -247,29 +249,30 @@ const App = () => {
                   title="kuisti"
                   error={error}
                 />
+                <SolisBox css={temperatureCss} />
               </>
             )}
 
             {view === "lights" && (
-              <LightGroups css={{ gridColumn: "1 / span 3" }} groups={groups} />
+              <LightGroups css={{ gridColumn: "1 / span 4" }} groups={groups} />
             )}
 
             {view === "motion" && (
               <Motion
-                css={{ gridColumn: "1 / span 3" }}
+                css={{ gridColumn: "1 / span 4" }}
                 sensors={outside.concat(insideCold).concat(inside)}
                 error={!!error}
               />
             )}
 
             {view === "history" && (
-              <History css={{ gridColumn: "1 / span 3" }} />
+              <History css={{ gridColumn: "1 / span 4" }} />
             )}
 
             {view === "settings" && (
               <div
                 css={{
-                  gridColumn: "1 / span 3",
+                  gridColumn: "1 / span 4",
                   backgroundColor: theme.colors.background.main,
                   boxShadow: theme.shadows.main,
                   borderRadius: 6,

--- a/frontend/src/components/Box.tsx
+++ b/frontend/src/components/Box.tsx
@@ -54,20 +54,17 @@ const Box: React.FC<BoxProps> = ({
   return (
     <div
       className={className}
-      css={[
-        {
-          cursor: "pointer",
-          height: "fit-content",
-          minWidth: 0,
-          overflow: "hidden",
-          boxShadow: theme.shadows.main,
-        },
-      ]}
+      css={{
+        cursor: "pointer",
+        minWidth: 0,
+        overflow: "hidden",
+        boxShadow: theme.shadows.main,
+      }}
       onClick={() => setCollapsed(!collapsed)}
     >
       <BoxHeader>{children}</BoxHeader>
       <BoxDrawer collapsed={collapsed}>{drawer}</BoxDrawer>
-      <BoxFooter collapsed={collapsed}></BoxFooter>
+      <BoxFooter collapsed={collapsed} />
     </div>
   );
 };

--- a/frontend/src/components/SolisBox.tsx
+++ b/frontend/src/components/SolisBox.tsx
@@ -1,0 +1,136 @@
+import { useTheme } from "@emotion/react";
+import { memo } from "react";
+import useSWR from "swr";
+
+import { api, fetcher } from "../api";
+import { SolisData } from "../types/solis";
+import Box from "./Box";
+import Icon from "./Icon";
+
+type SolisBoxProps = {
+  className?: string;
+};
+
+const SolisBox: React.FC<SolisBoxProps> = ({ className }) => {
+  const theme = useTheme();
+
+  const { data } = useSWR<SolisData>(api("/api/solis"), fetcher, {
+    refreshInterval: 300_000,
+    refreshWhenHidden: true,
+    shouldRetryOnError: false,
+  });
+
+  if (!data) return null;
+
+  const isAlarm = data.status === 3;
+  const displayPower = data.power.toFixed(1);
+
+  const batteryLabel =
+    data.battery_power !== null
+      ? data.battery_power > 0
+        ? "lataa"
+        : data.battery_power < 0
+          ? "purkaa"
+          : "lepotila"
+      : null;
+
+  return (
+    <Box
+      className={className}
+      drawer={
+        <div
+          css={{
+            backgroundColor: theme.colors.background.light,
+            padding: "5px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.5em",
+            fontSize: "14px",
+          }}
+        >
+          <DrawerRow
+            label="Tänään"
+            value={`${data.today_energy} ${data.today_energy_unit}`}
+          />
+          {data.battery_soc !== null && (
+            <>
+              <DrawerRow
+                label={`Akku`}
+                value={`${Math.round(data.battery_soc)}%`}
+              />
+              {data.battery_power && data.battery_power_unit && (
+                <DrawerRow
+                  label={`${batteryLabel}`}
+                  value={`${Math.abs(data.battery_power).toFixed(2)} ${data.battery_power_unit}`}
+                />
+              )}
+            </>
+          )}
+        </div>
+      }
+    >
+      <div
+        css={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flex: 1,
+        }}
+      >
+        <div
+          css={{
+            fontWeight: "normal",
+            fontSize: 18,
+            display: "flex",
+            alignItems: "center",
+            gap: "0.3em",
+          }}
+        >
+          <Icon
+            size={18}
+            css={{
+              color: isAlarm ? theme.colors.error : "inherit",
+              opacity: 0.7,
+            }}
+          >
+            {isAlarm ? "warning" : "solar_power"}
+          </Icon>
+          {data.power_unit}
+        </div>
+        <div
+          css={{
+            marginTop: "5px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <div
+            css={{
+              fontWeight: "normal",
+              fontSize: "50px",
+            }}
+          >
+            {displayPower}
+          </div>
+        </div>
+      </div>
+    </Box>
+  );
+};
+
+const DrawerRow: React.FC<{ label: string; value: string }> = ({
+  label,
+  value,
+}) => {
+  const theme = useTheme();
+  return (
+    <div css={{ display: "flex", justifyContent: "space-between", gap: "1em" }}>
+      <span css={{ color: theme.colors.text.muted }}>{label}</span>
+      <span>{value}</span>
+    </div>
+  );
+};
+
+export default memo(SolisBox);

--- a/frontend/src/components/TemperatureBox.tsx
+++ b/frontend/src/components/TemperatureBox.tsx
@@ -147,14 +147,14 @@ const TemperatureBox: React.FC<TemperatureBoxProps> = ({
             <div
               css={{
                 position: "absolute",
-                right: -36,
+                right: -30,
                 top: 0,
                 bottom: 0,
                 display: "flex",
                 alignItems: "center",
               }}
             >
-              <TrendIndicator trend={trend} size={32} />
+              <TrendIndicator trend={trend} />
             </div>
           )}
         </div>

--- a/frontend/src/types/solis.ts
+++ b/frontend/src/types/solis.ts
@@ -1,0 +1,20 @@
+export type SolisData = {
+  power: number;
+  power_unit: string;
+  today_energy: number;
+  today_energy_unit: string;
+  month_energy: number;
+  month_energy_unit: string;
+  year_energy: number;
+  year_energy_unit: string;
+  total_energy: number;
+  total_energy_unit: string;
+  grid_power: number | null;
+  grid_power_unit: string | null;
+  battery_soc: number | null;
+  battery_power: number | null;
+  battery_power_unit: string | null;
+  /** 1 = online, 2 = offline, 3 = alarm */
+  status: 1 | 2 | 3;
+  updated_at: number;
+};


### PR DESCRIPTION
## Summary

- Backend: new `/api/solis` endpoint authenticating with HMAC-SHA1 against the SolisCloud API, with a 5-minute cache and stale-data fallback on error
- Frontend: compact `SolisBox` added as a 4th column in the main temperature view, showing current power output (kW) and battery details in the drawer; auto-refreshes every 5 minutes
- Grid expanded from 3 to 4 columns; drawer opening no longer stretches sibling boxes (`align-items: start`)
- API reference doc added at `documentation/soliscloud-api.md`

## Config

Three new env vars required:
```
SOLIS_KEY_ID=
SOLIS_KEY_SECRET=
SOLIS_STATION_ID=
# SOLIS_BASE_URL=https://www.soliscloud.com:13333  # optional
```