### PR TITLE
Add 66h PV forecast overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ HCC_HISTORY_RETENTION_DAYS=90 # days of sensor history to keep (default: 0/disab
 # Maps room types to lists of room names as configured in the Hue app.
 # Rooms not listed default to "inside".
 HUE_ROOM_TYPES={"inside": ["Keittiö", "Olohuone"], "inside_cold": ["Kuisti"], "outside": ["Ulkona"]}
+
 ```
+
+PV forecast vars (`PV_LAT`, `PV_LON`, `PV_TILT`, `PV_AZIMUTH`, `PV_KW`) are
+consumed by `scripts/refresh-pv-forecast.sh` — see the "PV forecast"
+section below for details.
 
 ### Pairing with the Hue bridge
 
@@ -68,6 +73,56 @@ GET /api/history/sensors?sensor_id=<id>&hours=<n>
 |-------------|----------|---------|--------------------------------------|
 | `sensor_id` | no       | all     | Filter to a specific sensor          |
 | `hours`     | no       | 24      | Hours of history to return (max 720) |
+
+## PV forecast
+
+The backend exposes `GET/POST /api/pv/forecast`. The actual forecast is
+produced by an external one-shot CLI maintained in a separate repository,
+[fmi-pv-forecast-runner](https://github.com/eetu/fmi-pv-forecast-runner),
+which wraps the
+[FMI open PV forecast](https://github.com/fmidev/fmi-open-pv-forecast-packaged)
+package and emits the next ~66 hours of hourly output as JSON on stdout.
+
+Refreshing the forecast is a two-step shell pipeline: run the CLI, pipe
+its stdout to `POST /api/pv/forecast`. `scripts/refresh-pv-forecast.sh`
+wraps both:
+
+```bash
+# Auto-detect: uses local uv repo if ../fmi-pv-forecast-runner/ is checked out,
+# otherwise pulls the published Docker image.
+HCC_PV_ENV_FILE=.env.pv ./scripts/refresh-pv-forecast.sh
+
+# Force a specific mode:
+./scripts/refresh-pv-forecast.sh uv
+./scripts/refresh-pv-forecast.sh docker
+```
+
+Required env vars (place in `$HCC_PV_ENV_FILE` or export beforehand):
+`PV_LAT`, `PV_LON`, `PV_TILT`, `PV_AZIMUTH`, `PV_KW`. Optional overrides:
+`HCC_BACKEND_URL` (default `http://localhost:3000`), `PV_RUNNER_PATH`,
+`PV_RUNNER_IMAGE`.
+
+### Cold-start and periodic refresh
+
+Run the script once manually to populate the database after the first
+deploy. For a 3-hour refresh cadence (matching the upstream forecast
+update interval), add a host cron entry:
+
+```cron
+17 */3 * * * cd /opt/hcc && HCC_PV_ENV_FILE=/opt/hcc/.env.pv ./scripts/refresh-pv-forecast.sh >>/var/log/hcc-pv.log 2>&1
+```
+
+### Storage and rendering
+
+Hourly forecast points are upserted into the `pv_forecast_points` table
+(steady-state ≤66 rows) and rendered as bars on the daily weather chart,
+aggregated to kWh per day.
+
+### Geographic limits
+
+The FMI forecast covers Finland, Scandinavia, and the Baltic countries. See
+[ilmatieteenlaitos.fi/numerical-weather-prediction](https://en.ilmatieteenlaitos.fi/numerical-weather-prediction)
+for the full available area.
 
 ## Media
 

--- a/backend/src/hue/client.rs
+++ b/backend/src/hue/client.rs
@@ -13,6 +13,13 @@ pub enum HueError {
     Http(#[from] reqwest::Error),
     #[error("Bridge error {status}: {body}")]
     Bridge { status: u16, body: String },
+    #[error("Failed to decode response from {path}: {source} (body: {body})")]
+    Decode {
+        path: String,
+        body: String,
+        #[source]
+        source: serde_json::Error,
+    },
 }
 
 pub async fn hue_fetch<T: serde::de::DeserializeOwned>(
@@ -40,10 +47,32 @@ pub async fn hue_fetch<T: serde::de::DeserializeOwned>(
     if !res.status().is_success() {
         let status = res.status().as_u16();
         let body = res.text().await.unwrap_or_default();
+        tracing::error!(path, status, body = %truncate(&body, 500), "Hue bridge returned non-success");
         return Err(HueError::Bridge { status, body });
     }
 
-    Ok(res.json().await?)
+    let body = res.text().await?;
+    serde_json::from_str::<HueList<T>>(&body).map_err(|e| {
+        tracing::error!(
+            path,
+            error = %e,
+            body = %truncate(&body, 500),
+            "Failed to decode Hue response"
+        );
+        HueError::Decode {
+            path: path.to_string(),
+            body,
+            source: e,
+        }
+    })
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.len() <= n {
+        s.to_string()
+    } else {
+        format!("{}…[+{} bytes]", &s[..n], s.len() - n)
+    }
 }
 
 pub async fn hue_put(

--- a/backend/src/hue/data.rs
+++ b/backend/src/hue/data.rs
@@ -36,7 +36,11 @@ async fn fetch_from_bridge(state: &Arc<AppState>) -> Result<HueResponse, HueErro
     let battery_by_device: HashMap<&str, u8> = device_powers
         .data
         .iter()
-        .filter_map(|dp| dp.power_state.battery_level.map(|b| (dp.owner.rid.as_str(), b)))
+        .filter_map(|dp| {
+            dp.power_state
+                .battery_level
+                .map(|b| (dp.owner.rid.as_str(), b))
+        })
         .collect();
 
     // device ID → room
@@ -65,7 +69,7 @@ async fn fetch_from_bridge(state: &Arc<AppState>) -> Result<HueResponse, HueErro
         .map(|m| {
             let (motion, updated_at) = match &m.motion.motion_report {
                 Some(report) => (report.motion, Some(report.changed.as_str())),
-                None => (m.motion.motion, None),
+                None => (m.motion.motion.unwrap_or(false), None),
             };
             (m.owner.rid.as_str(), (motion, updated_at))
         })
@@ -108,11 +112,9 @@ async fn fetch_from_bridge(state: &Arc<AppState>) -> Result<HueResponse, HueErro
                 .temperature_report
                 .as_ref()
                 .map(|r| r.temperature)
-                .unwrap_or(temp.temperature.temperature);
+                .or(temp.temperature.temperature);
 
-            let battery = battery_by_device
-                .get(temp.owner.rid.as_str())
-                .copied();
+            let battery = battery_by_device.get(temp.owner.rid.as_str()).copied();
 
             let motion_data = motion_by_device.get(temp.owner.rid.as_str());
 
@@ -120,7 +122,7 @@ async fn fetch_from_bridge(state: &Arc<AppState>) -> Result<HueResponse, HueErro
                 id: temp.id.clone(),
                 device_id: temp.owner.rid.clone(),
                 name,
-                temperature: Some(temperature),
+                temperature,
                 room_type,
                 enabled: temp.enabled,
                 battery,

--- a/backend/src/hue/handlers.rs
+++ b/backend/src/hue/handlers.rs
@@ -43,13 +43,17 @@ pub async fn get_data(state: web::Data<Arc<AppState>>) -> HttpResponse {
         (status = 200, description = "Server-sent events stream of Hue device changes")
     )
 )]
-pub async fn events_sse(state: web::Data<Arc<AppState>>) -> sse::Sse<impl futures_util::Stream<Item = Result<sse::Event, std::convert::Infallible>>> {
+pub async fn events_sse(
+    state: web::Data<Arc<AppState>>,
+) -> sse::Sse<impl futures_util::Stream<Item = Result<sse::Event, std::convert::Infallible>>> {
     let rx = subscribe(&state.hue_events_tx);
     let stream = BroadcastStream::new(rx).filter_map(|result| async move {
         match result {
             Ok(event) => {
                 let json = serde_json::to_string(&event).ok()?;
-                Some(Ok::<_, std::convert::Infallible>(sse::Event::Data(sse::Data::new(json))))
+                Some(Ok::<_, std::convert::Infallible>(sse::Event::Data(
+                    sse::Data::new(json),
+                )))
             }
             Err(_) => None,
         }
@@ -86,10 +90,7 @@ pub struct PairResponse {
         (status = 400, description = "Pairing failed")
     )
 )]
-pub async fn pair(
-    state: web::Data<Arc<AppState>>,
-    body: web::Json<PairRequest>,
-) -> HttpResponse {
+pub async fn pair(state: web::Data<Arc<AppState>>, body: web::Json<PairRequest>) -> HttpResponse {
     let bridge_ip = body
         .bridge_ip
         .clone()
@@ -114,16 +115,14 @@ pub async fn pair(
     let res = match state.hue_client.post(&url).json(&payload).send().await {
         Ok(r) => r,
         Err(e) => {
-            return HttpResponse::BadRequest()
-                .json(serde_json::json!({"error": e.to_string()}));
+            return HttpResponse::BadRequest().json(serde_json::json!({"error": e.to_string()}));
         }
     };
 
     let entries: Vec<serde_json::Value> = match res.json().await {
         Ok(v) => v,
         Err(e) => {
-            return HttpResponse::BadRequest()
-                .json(serde_json::json!({"error": e.to_string()}));
+            return HttpResponse::BadRequest().json(serde_json::json!({"error": e.to_string()}));
         }
     };
 
@@ -133,8 +132,7 @@ pub async fn pair(
             .get("description")
             .and_then(|d| d.as_str())
             .unwrap_or("Pairing failed");
-        return HttpResponse::BadRequest()
-            .json(serde_json::json!({"error": desc}));
+        return HttpResponse::BadRequest().json(serde_json::json!({"error": desc}));
     }
 
     if let Some(success) = entry.get("success") {
@@ -184,8 +182,7 @@ pub async fn toggle_group(
         Ok(res) => res,
         Err(e) => {
             tracing::error!("Failed to get group {group_id}: {e}");
-            return HttpResponse::BadGateway()
-                .json(serde_json::json!({"error": e.to_string()}));
+            return HttpResponse::BadGateway().json(serde_json::json!({"error": e.to_string()}));
         }
     };
 
@@ -202,8 +199,7 @@ pub async fn toggle_group(
         Ok(()) => HttpResponse::Ok().finish(),
         Err(e) => {
             tracing::error!("Failed to toggle group {group_id}: {e}");
-            HttpResponse::BadGateway()
-                .json(serde_json::json!({"error": e.to_string()}))
+            HttpResponse::BadGateway().json(serde_json::json!({"error": e.to_string()}))
         }
     }
 }

--- a/backend/src/hue/models.rs
+++ b/backend/src/hue/models.rs
@@ -84,7 +84,8 @@ pub struct TemperatureResource {
 
 #[derive(Debug, Deserialize)]
 pub struct TemperatureData {
-    pub temperature: f64,
+    /// Absent on disabled temperature sensors — only `temperature_valid` is emitted then.
+    pub temperature: Option<f64>,
     pub temperature_report: Option<TemperatureReport>,
 }
 
@@ -141,7 +142,8 @@ pub struct MotionResource {
 
 #[derive(Debug, Deserialize)]
 pub struct MotionData {
-    pub motion: bool,
+    /// Absent on disabled motion sensors — only `motion_valid` is emitted then.
+    pub motion: Option<bool>,
     pub motion_report: Option<MotionReport>,
 }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cache;
 pub mod hue;
+pub mod pv;
 pub mod settings;
 pub mod solis;
 pub mod storage;
@@ -25,6 +26,7 @@ pub struct AppState {
     pub tomorrow_cache: Cache<serde_json::Value>,
     pub weather_cache: Cache<weather::models::WeatherResponse>,
     pub solis_cache: Cache<solis::models::SolisWidgetData>,
+    pub pv_cache: Cache<pv::models::PvForecast>,
     pub hue_events_tx: broadcast::Sender<hue::events::HueLiveEvent>,
     pub storage: storage::Storage,
 }
@@ -39,6 +41,8 @@ pub struct AppState {
         hue::handlers::pair,
         hue::handlers::toggle_group,
         solis::handlers::get_data,
+        pv::handlers::get_forecast,
+        pv::handlers::post_forecast,
         status,
         sensor_history,
     ),
@@ -52,6 +56,8 @@ pub struct AppState {
         hue::handlers::PairRequest,
         hue::handlers::PairResponse,
         solis::models::SolisWidgetData,
+        pv::models::PvForecast,
+        pv::models::PvPoint,
         StatusResponse,
         storage::SensorReading,
     ))
@@ -187,6 +193,13 @@ pub fn create_app(
                 .service(
                     web::scope("/solis")
                         .route("", web::get().to(solis::handlers::get_data)),
+                )
+                .service(
+                    web::scope("/pv").service(
+                        web::resource("/forecast")
+                            .route(web::get().to(pv::handlers::get_forecast))
+                            .route(web::post().to(pv::handlers::post_forecast)),
+                    ),
                 ),
         )
         .service(SwaggerUi::new("/docs/{_:.*}").url("/api-doc/openapi.json", openapi))
@@ -230,6 +243,7 @@ pub fn create_test_app_state_with(settings: Settings) -> Arc<AppState> {
         tomorrow_cache: Cache::new(std::time::Duration::from_secs(3600)),
         weather_cache: Cache::new(std::time::Duration::from_secs(3600)),
         solis_cache: Cache::new(std::time::Duration::from_secs(300)),
+        pv_cache: Cache::new(std::time::Duration::from_secs(60)),
         hue_events_tx,
         storage,
     })
@@ -268,6 +282,7 @@ pub async fn run_server() -> std::io::Result<()> {
         tomorrow_cache: Cache::new(std::time::Duration::from_secs(3600)),
         weather_cache: Cache::new(std::time::Duration::from_secs(3600)),
         solis_cache: Cache::new(std::time::Duration::from_secs(300)),
+        pv_cache: Cache::new(std::time::Duration::from_secs(60)),
         hue_events_tx: hue_events_tx.clone(),
         storage,
     });

--- a/backend/src/pv/handlers.rs
+++ b/backend/src/pv/handlers.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use actix_web::{web, HttpResponse};
+
+use super::models::PvForecast;
+use crate::AppState;
+
+const CACHE_KEY: &str = "pv";
+
+#[utoipa::path(
+    get,
+    path = "/api/pv/forecast",
+    responses(
+        (status = 200, description = "Latest PV forecast", body = super::models::PvForecast),
+        (status = 503, description = "No forecast available yet"),
+    )
+)]
+pub async fn get_forecast(state: web::Data<Arc<AppState>>) -> HttpResponse {
+    if let Some(cached) = state.pv_cache.get(CACHE_KEY).await {
+        return HttpResponse::Ok().json(cached);
+    }
+
+    match state.storage.read_pv_forecast().await {
+        Ok(Some(forecast)) => {
+            state.pv_cache.set(CACHE_KEY.into(), forecast.clone()).await;
+            HttpResponse::Ok().json(forecast)
+        }
+        Ok(None) => HttpResponse::ServiceUnavailable()
+            .json(serde_json::json!({"error": "no forecast available yet"})),
+        Err(e) => {
+            tracing::error!("Failed to read PV forecast: {e}");
+            HttpResponse::InternalServerError().finish()
+        }
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/pv/forecast",
+    request_body = super::models::PvForecast,
+    responses(
+        (status = 200, description = "Forecast upserted"),
+    )
+)]
+pub async fn post_forecast(
+    state: web::Data<Arc<AppState>>,
+    body: web::Json<PvForecast>,
+) -> HttpResponse {
+    let forecast = body.into_inner();
+    match state.storage.upsert_pv_forecast(&forecast).await {
+        Ok(n) => {
+            state.pv_cache.set(CACHE_KEY.into(), forecast).await;
+            tracing::info!("Upserted {n} PV forecast points");
+            HttpResponse::Ok().json(serde_json::json!({"upserted": n}))
+        }
+        Err(e) => {
+            tracing::error!("Failed to upsert PV forecast: {e}");
+            HttpResponse::InternalServerError().finish()
+        }
+    }
+}

--- a/backend/src/pv/mod.rs
+++ b/backend/src/pv/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+pub mod models;
+pub mod storage;

--- a/backend/src/pv/models.rs
+++ b/backend/src/pv/models.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PvPoint {
+    /// ISO8601 UTC hour
+    pub time: String,
+    pub output_w: f64,
+    pub temperature: Option<f64>,
+    pub wind: Option<f64>,
+    pub module_temp: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PvForecast {
+    /// When the forecast run was generated (ISO8601 UTC)
+    pub generated_at: String,
+    pub points: Vec<PvPoint>,
+}

--- a/backend/src/pv/storage.rs
+++ b/backend/src/pv/storage.rs
@@ -1,0 +1,90 @@
+use rusqlite::Connection;
+
+use super::models::{PvForecast, PvPoint};
+
+pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS pv_forecast_points (
+             time TEXT PRIMARY KEY,
+             output_w REAL NOT NULL,
+             temperature REAL,
+             wind REAL,
+             module_temp REAL,
+             generated_at TEXT NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS idx_pv_forecast_generated
+             ON pv_forecast_points(generated_at);",
+    )
+}
+
+pub fn upsert_forecast(conn: &Connection, forecast: &PvForecast) -> rusqlite::Result<usize> {
+    let tx = conn.unchecked_transaction()?;
+    let mut count = 0;
+    {
+        let mut stmt = tx.prepare(
+            "INSERT INTO pv_forecast_points
+                 (time, output_w, temperature, wind, module_temp, generated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(time) DO UPDATE SET
+                 output_w = excluded.output_w,
+                 temperature = excluded.temperature,
+                 wind = excluded.wind,
+                 module_temp = excluded.module_temp,
+                 generated_at = excluded.generated_at",
+        )?;
+        for p in &forecast.points {
+            stmt.execute(rusqlite::params![
+                p.time,
+                p.output_w,
+                p.temperature,
+                p.wind,
+                p.module_temp,
+                forecast.generated_at,
+            ])?;
+            count += 1;
+        }
+    }
+    tx.commit()?;
+    Ok(count)
+}
+
+pub fn read_forecast(conn: &Connection) -> rusqlite::Result<Option<PvForecast>> {
+    let mut stmt = conn.prepare(
+        "SELECT time, output_w, temperature, wind, module_temp, generated_at
+         FROM pv_forecast_points
+         WHERE time >= strftime('%Y-%m-%dT%H:00:00Z', 'now')
+         ORDER BY time ASC",
+    )?;
+
+    let mut generated_at: Option<String> = None;
+    let points: Vec<PvPoint> = stmt
+        .query_map([], |row| {
+            let gen_at: String = row.get(5)?;
+            generated_at.get_or_insert(gen_at);
+            Ok(PvPoint {
+                time: row.get(0)?,
+                output_w: row.get(1)?,
+                temperature: row.get(2)?,
+                wind: row.get(3)?,
+                module_temp: row.get(4)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    if points.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(PvForecast {
+        generated_at: generated_at.unwrap_or_default(),
+        points,
+    }))
+}
+
+pub fn prune_past(conn: &Connection) -> rusqlite::Result<usize> {
+    conn.execute(
+        "DELETE FROM pv_forecast_points
+         WHERE time < strftime('%Y-%m-%dT%H:00:00Z', 'now', '-12 hours')",
+        [],
+    )
+}

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -8,6 +8,8 @@ use tokio::sync::Mutex;
 use utoipa::ToSchema;
 
 use crate::hue::data::fetch_hue_data;
+use crate::pv::models::PvForecast;
+use crate::pv::storage as pv_storage;
 use crate::AppState;
 
 pub struct Storage {
@@ -54,9 +56,26 @@ impl Storage {
              INSERT OR IGNORE INTO user_settings (id, data) VALUES (1, '{}');",
         )?;
 
+        pv_storage::init_schema(&conn)?;
+
         Ok(Self {
             conn: Mutex::new(conn),
         })
+    }
+
+    pub async fn upsert_pv_forecast(&self, forecast: &PvForecast) -> rusqlite::Result<usize> {
+        let conn = self.conn.lock().await;
+        pv_storage::upsert_forecast(&conn, forecast)
+    }
+
+    pub async fn read_pv_forecast(&self) -> rusqlite::Result<Option<PvForecast>> {
+        let conn = self.conn.lock().await;
+        pv_storage::read_forecast(&conn)
+    }
+
+    pub async fn prune_pv_forecast(&self) -> rusqlite::Result<usize> {
+        let conn = self.conn.lock().await;
+        pv_storage::prune_past(&conn)
     }
 
     pub async fn insert_readings(&self, readings: &[SensorReading]) -> rusqlite::Result<()> {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@floating-ui/react": "^0.27.19",
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "classnames": "^2.5.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^1.11.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -150,17 +150,17 @@ const App = () => {
         css={{
           width: 720,
           flexShrink: 0,
+          padding: "16px 0",
           [mq[0]]: {
             width: "100%",
             flexShrink: 1,
-            padding: "0 12px",
+            padding: "12px",
             boxSizing: "border-box",
           },
         }}
       >
         <CurrentTime
           css={{
-            marginTop: "2em",
             [mq[0]]: { fontSize: "12px" },
           }}
         />

--- a/frontend/src/components/FmiWeatherBox.tsx
+++ b/frontend/src/components/FmiWeatherBox.tsx
@@ -6,6 +6,7 @@ import useSWR from "swr";
 
 import { api, fetcher } from "../api";
 import useLocationSettings from "../hooks/useLocationSettings";
+import { PvForecast } from "../types/pv";
 import { WeatherData } from "../types/weather/fmi";
 import {
   getFmiWeatherDescription,
@@ -36,6 +37,17 @@ const WeatherBox: React.FC<WeatherBoxProps> = ({ className }) => {
     refreshWhenHidden: true,
   });
 
+  const { data: pvForecast } = useSWR<PvForecast>(
+    api("/api/pv/forecast"),
+    (url: string) =>
+      fetch(url).then((res) => (res.ok ? res.json() : undefined)),
+    {
+      refreshInterval: 3600000,
+      refreshWhenHidden: true,
+      shouldRetryOnError: false,
+    },
+  );
+
   const current = data?.current;
   const daily = data?.daily ?? [];
   const today = daily[0];
@@ -65,13 +77,23 @@ const WeatherBox: React.FC<WeatherBoxProps> = ({ className }) => {
     return null;
   }
 
-  const chartData = daily.map((d) => ({
-    temp: d.temperatureMax,
-    rain: d.precipitation,
-    label: `${format(new Date(d.date), "EEEEEE", {
-      locale: fi,
-    })}`,
-  }));
+  const pvByDate = new Map<string, number>();
+  for (const p of pvForecast?.points ?? []) {
+    const key = p.time.slice(0, 10);
+    pvByDate.set(key, (pvByDate.get(key) ?? 0) + p.outputW / 1000);
+  }
+
+  const chartData = daily.map((d) => {
+    const key = d.date.slice(0, 10);
+    return {
+      temp: d.temperatureMax,
+      rain: d.precipitation,
+      pvKwh: pvByDate.has(key) ? pvByDate.get(key)! : null,
+      label: `${format(new Date(d.date), "EEEEEE", {
+        locale: fi,
+      })}`,
+    };
+  });
 
   const segments = getFmiTemperatureSegments(hourly);
 
@@ -93,7 +115,7 @@ const WeatherBox: React.FC<WeatherBoxProps> = ({ className }) => {
             padding: 10,
           }}
         >
-          <WeatherChart data={chartData} />
+          <WeatherChart data={chartData} days={7} />
         </div>
       }
     >

--- a/frontend/src/components/WeatherChart.tsx
+++ b/frontend/src/components/WeatherChart.tsx
@@ -11,8 +11,10 @@ import {
   LineElement,
   PointElement,
 } from "chart.js";
+import ChartDataLabels, { Context } from "chartjs-plugin-datalabels";
 import React from "react";
 import { Chart } from "react-chartjs-2";
+import { useMediaQuery } from "usehooks-ts";
 
 ChartJS.register(
   BarController,
@@ -22,44 +24,95 @@ ChartJS.register(
   PointElement,
   LineElement,
   LineController,
+  ChartDataLabels,
 );
 
 type WeatherChartData = {
   temp: number;
   rain: number;
+  pvKwh?: number | null;
   label: string;
 };
 
 type WeatherChartProps = {
   data: Array<WeatherChartData>;
+  days?: number;
 };
 
-const WeatherChart: React.FC<WeatherChartProps> = ({ data }) => {
+const WeatherChart: React.FC<WeatherChartProps> = ({
+  data: unfilteredData,
+  days,
+}) => {
   const theme = useTheme();
+  const isMobile = useMediaQuery("(max-width: 600px)");
+  const labelFontSize = isMobile ? 8 : 10;
+  const labelCharPx = isMobile ? 5 : 6.5;
+
+  const data =
+    days === undefined ? unfilteredData : unfilteredData.slice(0, days);
 
   const avgTemp =
     data.map((d) => d.temp).reduce((a, b) => a + b, 0) / data.length;
 
   const weatherLineColor = avgTemp < 5 ? theme.colors.cool : theme.colors.warm;
 
+  const hasPv = data.some((d) => d.pvKwh != null);
+
+  const datasets: ChartData["datasets"] = [
+    {
+      type: "line",
+      yAxisID: "yTemp",
+      data: data.map((d) => d.temp),
+      borderColor: weatherLineColor,
+      pointRadius: 0,
+      cubicInterpolationMode: "monotone",
+    },
+    {
+      type: "bar",
+      yAxisID: "yRain",
+      data: data.map((d) => d.rain),
+      backgroundColor: theme.mode === "dark" ? "#43529c" : "#94daf7",
+    },
+  ];
+
+  if (hasPv) {
+    datasets.push({
+      type: "bar",
+      yAxisID: "yPv",
+      data: data.map((d) => d.pvKwh ?? null),
+      backgroundColor: theme.mode === "dark" ? "#a35a00" : "#f5a524",
+      borderRadius: 2,
+      barPercentage: 0.5,
+      categoryPercentage: 0.7,
+      datalabels: {
+        display: true,
+        anchor: "center",
+        align: "center",
+        rotation: -90,
+        clip: false,
+        font: { size: labelFontSize, weight: "bold" },
+        formatter: (v: number | null) =>
+          v == null ? "" : `${v.toFixed(0)} kWh`,
+        color: (ctx: Context) => {
+          const value = ctx.dataset.data[ctx.dataIndex] as number | null;
+          if (value == null) return "#ffffff";
+          const scale = ctx.chart.scales.yPv;
+          if (!scale) return "#ffffff";
+          const barHeight = Math.abs(
+            scale.getPixelForValue(value) - scale.getPixelForValue(0),
+          );
+          const text = `${value.toFixed(0)} kWh`;
+          const labelPx = text.length * labelCharPx + 4;
+          if (barHeight >= labelPx) return "#ffffff";
+          return theme.mode === "dark" ? "#f5a524" : "#a35a00";
+        },
+      },
+    });
+  }
+
   const chartData: ChartData = {
     labels: data.map((d) => d.label),
-    datasets: [
-      {
-        type: "line",
-        yAxisID: "yTemp",
-        data: data.map((d) => d.temp),
-        borderColor: weatherLineColor,
-        pointRadius: 0,
-        cubicInterpolationMode: "monotone",
-      },
-      {
-        type: "bar",
-        yAxisID: "yRain",
-        data: data.map((d) => d.rain),
-        backgroundColor: theme.mode === "dark" ? "#43529c" : "#94daf7",
-      },
-    ],
+    datasets,
   };
 
   const options: ChartOptions = {
@@ -68,6 +121,8 @@ const WeatherChart: React.FC<WeatherChartProps> = ({ data }) => {
     plugins: {
       legend: { display: false },
       tooltip: { enabled: false },
+      // Disabled by default — re-enabled per-dataset (PV bars only).
+      datalabels: { display: false },
     },
     scales: {
       x: {
@@ -99,6 +154,16 @@ const WeatherChart: React.FC<WeatherChartProps> = ({ data }) => {
           callback: (v) => `${v} mm`,
         },
       },
+      ...(hasPv
+        ? {
+            yPv: {
+              position: "right",
+              display: false,
+              beginAtZero: true,
+              grid: { drawOnChartArea: false },
+            },
+          }
+        : {}),
     },
   };
 

--- a/frontend/src/types/pv.ts
+++ b/frontend/src/types/pv.ts
@@ -1,0 +1,12 @@
+export type PvPoint = {
+  time: string;
+  outputW: number;
+  temperature: number | null;
+  wind: number | null;
+  moduleTemp: number | null;
+};
+
+export type PvForecast = {
+  generatedAt: string;
+  points: PvPoint[];
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1924,6 +1924,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chartjs-plugin-datalabels@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "chartjs-plugin-datalabels@npm:2.2.0"
+  peerDependencies:
+    chart.js: ">=3.0.0"
+  checksum: 10/e87c2f30d4f6f84b4b1a28c00d1b032d0100f87f8f296a498507047bd2f7fe98eced583a2c09f30e55806e79a0ca7e0db027cc3bed9b27688980e55701a6945f
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^2.0.0":
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
@@ -5573,6 +5582,7 @@ __metadata:
     babel-plugin-react-compiler: "npm:^1.0.0"
     chart.js: "npm:^4.5.1"
     chartjs-adapter-date-fns: "npm:^3.0.0"
+    chartjs-plugin-datalabels: "npm:^2.2.0"
     classnames: "npm:^2.5.1"
     date-fns: "npm:^4.1.0"
     eslint: "npm:^9.39.4"

--- a/scripts/refresh-pv-forecast.sh
+++ b/scripts/refresh-pv-forecast.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Refresh the PV forecast in the HCC backend.
+#
+# Usage:
+#   scripts/refresh-pv-forecast.sh                  # auto-detect: uv if local repo present, else docker
+#   scripts/refresh-pv-forecast.sh uv               # force local uv invocation
+#   scripts/refresh-pv-forecast.sh docker           # force docker invocation
+#
+# Required env (sourced from $HCC_PV_ENV_FILE if set, otherwise inherited):
+#   PV_LAT, PV_LON, PV_TILT, PV_AZIMUTH, PV_KW
+# Optional:
+#   HCC_BACKEND_URL  default http://localhost:3000
+#   PV_RUNNER_PATH   path to local fmi-pv-forecast-runner repo (default: ../fmi-pv-forecast-runner)
+#   PV_RUNNER_IMAGE  docker image to use (default: ghcr.io/eetu/fmi-pv-forecast-runner:latest)
+#   HCC_PV_ENV_FILE  path to a .env file to source for PV_* vars
+
+set -euo pipefail
+
+mode="${1:-auto}"
+backend_url="${HCC_BACKEND_URL:-http://localhost:3000}"
+runner_path="${PV_RUNNER_PATH:-../fmi-pv-forecast-runner}"
+runner_image="${PV_RUNNER_IMAGE:-ghcr.io/eetu/fmi-pv-forecast-runner:latest}"
+
+if [[ -n "${HCC_PV_ENV_FILE:-}" && -f "$HCC_PV_ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$HCC_PV_ENV_FILE"
+  set +a
+fi
+
+for var in PV_LAT PV_LON PV_TILT PV_AZIMUTH PV_KW; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "missing required env: $var" >&2
+    exit 1
+  fi
+done
+
+if [[ "$mode" == "auto" ]]; then
+  if [[ -f "$runner_path/pyproject.toml" ]] && command -v uv >/dev/null 2>&1; then
+    mode="uv"
+  else
+    mode="docker"
+  fi
+fi
+
+case "$mode" in
+  uv)
+    echo "running fmi-pv-forecast-runner via uv at $runner_path" >&2
+    forecast_json=$(
+      cd "$runner_path"
+      PV_LAT="$PV_LAT" PV_LON="$PV_LON" PV_TILT="$PV_TILT" \
+        PV_AZIMUTH="$PV_AZIMUTH" PV_KW="$PV_KW" \
+        uv run --quiet python run.py
+    )
+    ;;
+  docker)
+    echo "running fmi-pv-forecast-runner via docker image $runner_image" >&2
+    forecast_json=$(
+      docker run --rm \
+        -e PV_LAT="$PV_LAT" \
+        -e PV_LON="$PV_LON" \
+        -e PV_TILT="$PV_TILT" \
+        -e PV_AZIMUTH="$PV_AZIMUTH" \
+        -e PV_KW="$PV_KW" \
+        "$runner_image"
+    )
+    ;;
+  *)
+    echo "unknown mode: $mode (expected: auto, uv, docker)" >&2
+    exit 1
+    ;;
+esac
+
+echo "posting forecast to $backend_url/api/pv/forecast" >&2
+curl -fsS \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  --data-binary "$forecast_json" \
+  "$backend_url/api/pv/forecast"
+echo


### PR DESCRIPTION
## Summary

- Adds a 66-hour PV power forecast pipeline backed by the standalone [fmi-pv-forecast-runner](https://github.com/eetu/fmi-pv-forecast-runner) CLI (separate repo, runs out-of-process, emits JSON on stdout). HCC ingests via a new `POST /api/pv/forecast` endpoint, persists ≤66 rows in a `pv_forecast_points` table that upserts on the `time` PK, and renders the result as per-day kWh bars on the existing weather chart with rotated in-bar labels.
- Hardens the Hue client against disabled-sensor field omissions (`temperature.temperature` and `motion.motion` both missing on disabled devices). Strict struct fields previously took the entire dashboard down whenever a single disabled sensor was in the response. Adds diagnostic logging that surfaces the failing path and a truncated body so the next firmware schema drift is easy to spot.

## Operations

- Manual cold-start: `./scripts/refresh-pv-forecast.sh` (auto-detects local uv repo vs Docker image)
- Periodic refresh via host cron, e.g. `17 */3 * * * cd /opt/hcc && HCC_PV_ENV_FILE=/opt/hcc/.env.pv ./scripts/refresh-pv-forecast.sh >>/var/log/hcc-pv.log 2>&1`
- Configuration via `PV_LAT`, `PV_LON`, `PV_TILT`, `PV_AZIMUTH`, `PV_KW`

## Test plan

- [ ] `cargo build`, `cargo clippy -- -D warnings`, `cargo test --lib` pass on backend
- [ ] `yarn lint`, `yarn tsc --noEmit` pass on frontend
- [ ] `GET /api/pv/forecast` returns 503 when DB is empty (cold-start state)
- [ ] `POST /api/pv/forecast` upserts a known fixture and `GET` returns it
- [ ] Subsequent POSTs with overlapping `time` values overwrite, table stays ≤66 rows
- [ ] Run `scripts/refresh-pv-forecast.sh uv` against a checked-out runner repo and a local backend, verify chart renders kWh bars
- [ ] Run `scripts/refresh-pv-forecast.sh docker` once the runner image is published to GHCR
- [ ] Trigger Hue dashboard polling against a bridge that has at least one disabled motion or temperature sensor — full sensor list should still render
- [ ] Verify mobile chart renders smaller (8px bold) labels at ≤600px viewport