### PR TITLE
Toggle Hue motion sensors from UI

### DIFF
--- a/backend/src/cache.rs
+++ b/backend/src/cache.rs
@@ -50,6 +50,13 @@ impl<T: Clone> Cache<T> {
         });
     }
 
+    pub async fn invalidate(&self, key: &str) {
+        let mut guard = self.inner.write().await;
+        if guard.as_ref().is_some_and(|entry| entry.key == key) {
+            *guard = None;
+        }
+    }
+
     pub async fn has_data(&self) -> bool {
         self.inner.read().await.is_some()
     }

--- a/backend/src/hue/data.rs
+++ b/backend/src/hue/data.rs
@@ -63,7 +63,7 @@ async fn fetch_from_bridge(state: &Arc<AppState>) -> Result<HueResponse, HueErro
         .collect();
 
     // device ID → motion data
-    let motion_by_device: HashMap<&str, (bool, Option<&str>)> = motions
+    let motion_by_device: HashMap<&str, (bool, Option<&str>, bool)> = motions
         .data
         .iter()
         .map(|m| {
@@ -71,7 +71,7 @@ async fn fetch_from_bridge(state: &Arc<AppState>) -> Result<HueResponse, HueErro
                 Some(report) => (report.motion, Some(report.changed.as_str())),
                 None => (m.motion.motion.unwrap_or(false), None),
             };
-            (m.owner.rid.as_str(), (motion, updated_at))
+            (m.owner.rid.as_str(), (motion, updated_at, m.enabled))
         })
         .collect();
 
@@ -126,8 +126,9 @@ async fn fetch_from_bridge(state: &Arc<AppState>) -> Result<HueResponse, HueErro
                 room_type,
                 enabled: temp.enabled,
                 battery,
-                motion: motion_data.map(|(m, _)| *m),
-                motion_updated_at: motion_data.and_then(|(_, u)| u.map(String::from)),
+                motion: motion_data.map(|(m, _, _)| *m),
+                motion_updated_at: motion_data.and_then(|(_, u, _)| u.map(String::from)),
+                motion_enabled: motion_data.map(|(_, _, e)| *e),
                 connected: connected_by_device
                     .get(temp.owner.rid.as_str())
                     .copied()

--- a/backend/src/hue/events.rs
+++ b/backend/src/hue/events.rs
@@ -32,6 +32,11 @@ pub enum HueLiveEvent {
         #[serde(rename = "updatedAt")]
         updated_at: String,
     },
+    MotionEnabled {
+        #[serde(rename = "deviceId")]
+        device_id: String,
+        enabled: bool,
+    },
     Connectivity {
         #[serde(rename = "deviceId")]
         device_id: String,
@@ -100,7 +105,7 @@ async fn stream_events(state: &Arc<AppState>) -> Result<(), Box<dyn std::error::
                     continue;
                 }
                 for resource in envelope.data {
-                    if let Some(event) = parse_resource_update(&resource) {
+                    for event in parse_resource_update(&resource) {
                         let _ = state.hue_events_tx.send(event);
                     }
                 }
@@ -117,52 +122,103 @@ struct EventEnvelope {
     data: Vec<serde_json::Value>,
 }
 
-fn parse_resource_update(resource: &serde_json::Value) -> Option<HueLiveEvent> {
-    let rtype = resource.get("type")?.as_str()?;
+fn parse_resource_update(resource: &serde_json::Value) -> Vec<HueLiveEvent> {
+    let Some(rtype) = resource.get("type").and_then(|v| v.as_str()) else {
+        return Vec::new();
+    };
     match rtype {
-        "grouped_light" => {
-            let on = resource.get("on")?.get("on")?.as_bool()?;
-            let id = resource.get("id")?.as_str()?.to_string();
-            Some(HueLiveEvent::GroupedLight { id, on })
-        }
-        "temperature" => {
-            let temp_obj = resource.get("temperature")?;
-            let temperature = temp_obj
-                .get("temperature_report")
-                .and_then(|r| r.get("temperature"))
-                .or_else(|| temp_obj.get("temperature"))?
-                .as_f64()?;
-            let id = resource.get("id")?.as_str()?.to_string();
-            Some(HueLiveEvent::Temperature { id, temperature })
-        }
-        "device_power" => {
-            let battery = resource
-                .get("power_state")?
-                .get("battery_level")?
-                .as_u64()? as u8;
-            let device_id = resource.get("owner")?.get("rid")?.as_str()?.to_string();
-            Some(HueLiveEvent::DevicePower { device_id, battery })
-        }
+        "grouped_light" => resource
+            .get("on")
+            .and_then(|o| o.get("on"))
+            .and_then(|o| o.as_bool())
+            .zip(resource.get("id").and_then(|v| v.as_str()))
+            .map(|(on, id)| {
+                vec![HueLiveEvent::GroupedLight {
+                    id: id.to_string(),
+                    on,
+                }]
+            })
+            .unwrap_or_default(),
+        "temperature" => resource
+            .get("temperature")
+            .and_then(|temp_obj| {
+                temp_obj
+                    .get("temperature_report")
+                    .and_then(|r| r.get("temperature"))
+                    .or_else(|| temp_obj.get("temperature"))
+                    .and_then(|t| t.as_f64())
+            })
+            .zip(resource.get("id").and_then(|v| v.as_str()))
+            .map(|(temperature, id)| {
+                vec![HueLiveEvent::Temperature {
+                    id: id.to_string(),
+                    temperature,
+                }]
+            })
+            .unwrap_or_default(),
+        "device_power" => resource
+            .get("power_state")
+            .and_then(|s| s.get("battery_level"))
+            .and_then(|b| b.as_u64())
+            .zip(
+                resource
+                    .get("owner")
+                    .and_then(|o| o.get("rid"))
+                    .and_then(|r| r.as_str()),
+            )
+            .map(|(battery, device_id)| {
+                vec![HueLiveEvent::DevicePower {
+                    device_id: device_id.to_string(),
+                    battery: battery as u8,
+                }]
+            })
+            .unwrap_or_default(),
         "motion" => {
-            let report = resource.get("motion")?.get("motion_report")?;
-            let motion = report.get("motion")?.as_bool()?;
-            let updated_at = report.get("changed")?.as_str()?.to_string();
-            let device_id = resource.get("owner")?.get("rid")?.as_str()?.to_string();
-            Some(HueLiveEvent::Motion {
-                device_id,
-                motion,
-                updated_at,
-            })
+            let Some(device_id) = resource
+                .get("owner")
+                .and_then(|o| o.get("rid"))
+                .and_then(|r| r.as_str())
+            else {
+                return Vec::new();
+            };
+            let mut events = Vec::new();
+            if let Some(enabled) = resource.get("enabled").and_then(|e| e.as_bool()) {
+                events.push(HueLiveEvent::MotionEnabled {
+                    device_id: device_id.to_string(),
+                    enabled,
+                });
+            }
+            if let Some(report) = resource.get("motion").and_then(|m| m.get("motion_report")) {
+                if let (Some(motion), Some(updated_at)) = (
+                    report.get("motion").and_then(|m| m.as_bool()),
+                    report.get("changed").and_then(|c| c.as_str()),
+                ) {
+                    events.push(HueLiveEvent::Motion {
+                        device_id: device_id.to_string(),
+                        motion,
+                        updated_at: updated_at.to_string(),
+                    });
+                }
+            }
+            events
         }
-        "zigbee_connectivity" => {
-            let status = resource.get("status")?.as_str()?;
-            let device_id = resource.get("owner")?.get("rid")?.as_str()?.to_string();
-            Some(HueLiveEvent::Connectivity {
-                device_id,
-                connected: status == "connected",
+        "zigbee_connectivity" => resource
+            .get("status")
+            .and_then(|s| s.as_str())
+            .zip(
+                resource
+                    .get("owner")
+                    .and_then(|o| o.get("rid"))
+                    .and_then(|r| r.as_str()),
+            )
+            .map(|(status, device_id)| {
+                vec![HueLiveEvent::Connectivity {
+                    device_id: device_id.to_string(),
+                    connected: status == "connected",
+                }]
             })
-        }
-        _ => None,
+            .unwrap_or_default(),
+        _ => Vec::new(),
     }
 }
 

--- a/backend/src/hue/handlers.rs
+++ b/backend/src/hue/handlers.rs
@@ -12,7 +12,7 @@ use crate::AppState;
 use super::client::{hue_fetch, hue_put};
 use super::data::fetch_hue_data;
 use super::events::subscribe;
-use super::models::GroupedLightResource;
+use super::models::{GroupedLightResource, MotionResource};
 
 // ---- GET /api/hue ----
 
@@ -199,6 +199,64 @@ pub async fn toggle_group(
         Ok(()) => HttpResponse::Ok().finish(),
         Err(e) => {
             tracing::error!("Failed to toggle group {group_id}: {e}");
+            HttpResponse::BadGateway().json(serde_json::json!({"error": e.to_string()}))
+        }
+    }
+}
+
+// ---- POST /api/hue/toggleMotion/{deviceId} ----
+
+#[utoipa::path(
+    post,
+    path = "/api/hue/toggleMotion/{deviceId}",
+    params(("deviceId" = String, Path, description = "Hue device ID owning the motion service")),
+    responses(
+        (status = 200, description = "Motion sensor toggled"),
+        (status = 404, description = "Motion service not found for device"),
+        (status = 502, description = "Failed to toggle motion sensor")
+    )
+)]
+pub async fn toggle_motion(
+    state: web::Data<Arc<AppState>>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    let device_id = path.into_inner();
+
+    let motions = match hue_fetch::<MotionResource>(&state, "/clip/v2/resource/motion").await {
+        Ok(res) => res,
+        Err(e) => {
+            tracing::error!("Failed to list motion services: {e}");
+            return HttpResponse::BadGateway().json(serde_json::json!({"error": e.to_string()}));
+        }
+    };
+
+    let Some(service) = motions.data.iter().find(|m| m.owner.rid == device_id) else {
+        return HttpResponse::NotFound()
+            .json(serde_json::json!({"error": "Motion service not found for device"}));
+    };
+
+    let new_enabled = !service.enabled;
+    let body = serde_json::json!({"enabled": new_enabled});
+
+    match hue_put(
+        &state,
+        &format!("/clip/v2/resource/motion/{}", service.id),
+        &body,
+    )
+    .await
+    {
+        Ok(()) => {
+            state.hue_cache.invalidate("hue").await;
+            let _ = state
+                .hue_events_tx
+                .send(super::events::HueLiveEvent::MotionEnabled {
+                    device_id,
+                    enabled: new_enabled,
+                });
+            HttpResponse::Ok().json(serde_json::json!({"enabled": new_enabled}))
+        }
+        Err(e) => {
+            tracing::error!("Failed to toggle motion {}: {e}", service.id);
             HttpResponse::BadGateway().json(serde_json::json!({"error": e.to_string()}))
         }
     }

--- a/backend/src/hue/models.rs
+++ b/backend/src/hue/models.rs
@@ -26,6 +26,8 @@ pub struct Sensor {
     pub motion: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub motion_updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub motion_enabled: Option<bool>,
     pub connected: bool,
 }
 
@@ -136,7 +138,9 @@ pub struct PowerState {
 
 #[derive(Debug, Deserialize)]
 pub struct MotionResource {
+    pub id: String,
     pub owner: Owner,
+    pub enabled: bool,
     pub motion: MotionData,
 }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -40,6 +40,7 @@ pub struct AppState {
         hue::handlers::events_sse,
         hue::handlers::pair,
         hue::handlers::toggle_group,
+        hue::handlers::toggle_motion,
         solis::handlers::get_data,
         pv::handlers::get_forecast,
         pv::handlers::post_forecast,
@@ -188,6 +189,10 @@ pub fn create_app(
                         .route(
                             "/toggleGroup/{id}",
                             web::post().to(hue::handlers::toggle_group),
+                        )
+                        .route(
+                            "/toggleMotion/{deviceId}",
+                            web::post().to(hue::handlers::toggle_motion),
                         ),
                 )
                 .service(

--- a/backend/tests/smoke.rs
+++ b/backend/tests/smoke.rs
@@ -1,7 +1,7 @@
 use actix_web::{test, web, App};
 use hcc_backend::settings::Settings;
 use hcc_backend::{create_test_app_state, create_test_app_state_with, hue, weather};
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Build a test app with only the API routes (no static file serving).
@@ -33,6 +33,10 @@ fn test_app(
                         .route(
                             "/toggleGroup/{id}",
                             web::post().to(hue::handlers::toggle_group),
+                        )
+                        .route(
+                            "/toggleMotion/{deviceId}",
+                            web::post().to(hue::handlers::toggle_motion),
                         ),
                 ),
         )
@@ -393,6 +397,70 @@ async fn hue_toggle_toggles_group() {
     let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), 200);
+}
+
+#[actix_web::test]
+async fn hue_toggle_motion_toggles_enabled() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/clip/v2/resource/motion"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [
+                {"id": "motion-1", "owner": {"rid": "device-1"}, "enabled": true, "motion": {"motion": false}},
+                {"id": "motion-2", "owner": {"rid": "device-2"}, "enabled": false, "motion": {"motion": null}}
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let put_mock = Mock::given(method("PUT"))
+        .and(path("/clip/v2/resource/motion/motion-1"))
+        .and(body_json(serde_json::json!({"enabled": false})))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount_as_scoped(&mock_server)
+        .await;
+
+    let settings = test_settings_with_mock(&mock_server.uri());
+    let state = create_test_app_state_with(settings);
+    let app = test::init_service(test_app(state)).await;
+
+    let req = test::TestRequest::post()
+        .uri("/api/hue/toggleMotion/device-1")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body["enabled"], false);
+    drop(put_mock);
+}
+
+#[actix_web::test]
+async fn hue_toggle_motion_unknown_device_returns_404() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/clip/v2/resource/motion"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [
+                {"id": "motion-1", "owner": {"rid": "device-1"}, "enabled": true, "motion": {"motion": false}}
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let settings = test_settings_with_mock(&mock_server.uri());
+    let state = create_test_app_state_with(settings);
+    let app = test::init_service(test_app(state)).await;
+
+    let req = test::TestRequest::post()
+        .uri("/api/hue/toggleMotion/missing-device")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 404);
 }
 
 // ---- Routing ----

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,15 @@ const applyEvent = (data: Response, event: HueLiveEvent): Response => {
             : s,
         ),
       };
+    case "motion_enabled":
+      return {
+        ...data,
+        sensors: data.sensors.map((s) =>
+          s.deviceId === event.deviceId
+            ? { ...s, motionEnabled: event.enabled }
+            : s,
+        ),
+      };
     case "connectivity":
       return {
         ...data,

--- a/frontend/src/components/Motion.tsx
+++ b/frontend/src/components/Motion.tsx
@@ -1,9 +1,11 @@
 import { useTheme } from "@emotion/react";
 import { formatDistanceToNow } from "date-fns";
 import { fi } from "date-fns/locale/fi";
-import { FC, memo } from "react";
+import { FC, memo, useState } from "react";
 
+import { api } from "../api";
 import { Sensor } from "../types/hue";
+import Icon from "./Icon";
 
 type MotionProps = {
   className?: string;
@@ -13,7 +15,24 @@ type MotionProps = {
 
 const Motion: FC<MotionProps> = ({ className, sensors = [], error }) => {
   const theme = useTheme();
-  const motionSensors = sensors.filter((s) => s.motion !== undefined);
+  const [pending, setPending] = useState<Set<string>>(new Set());
+  const motionSensors = sensors.filter(
+    (s) => s.motion !== undefined || s.motionEnabled !== undefined,
+  );
+
+  const toggle = async (deviceId: string) => {
+    if (pending.has(deviceId)) return;
+    setPending((p) => new Set(p).add(deviceId));
+    try {
+      await fetch(api(`/api/hue/toggleMotion/${deviceId}`), { method: "POST" });
+    } finally {
+      setPending((p) => {
+        const next = new Set(p);
+        next.delete(deviceId);
+        return next;
+      });
+    }
+  };
 
   return (
     <div
@@ -29,62 +48,100 @@ const Motion: FC<MotionProps> = ({ className, sensors = [], error }) => {
         padding: "1.5em",
       }}
     >
-      {motionSensors.map((s) => (
-        <div
-          key={s.id}
-          css={{
-            display: "table-row",
-            backgroundColor: s.motion
-              ? theme.colors.activity.onBackground
-              : "transparent",
-          }}
-        >
-          <span
+      {motionSensors.map((s) => {
+        const enabled = s.motionEnabled !== false;
+        const active = enabled && s.motion;
+        return (
+          <div
+            key={s.id}
             css={{
-              display: "table-cell",
-              padding: "8px 4px",
-              verticalAlign: "middle",
+              display: "table-row",
+              backgroundColor: active
+                ? theme.colors.activity.onBackground
+                : "transparent",
+              opacity: enabled ? 1 : 0.5,
             }}
           >
-            <span css={{ fontWeight: s.motion ? "bold" : "normal" }}>
-              {s.name}
+            <span
+              css={{
+                display: "table-cell",
+                padding: "8px 4px",
+                verticalAlign: "middle",
+                width: 32,
+              }}
+            >
+              <button
+                onClick={() => toggle(s.deviceId)}
+                disabled={pending.has(s.deviceId)}
+                aria-label={
+                  enabled ? "Poista liiketunnistin käytöstä" : "Ota käyttöön"
+                }
+                css={{
+                  cursor: pending.has(s.deviceId) ? "wait" : "pointer",
+                  background: "transparent",
+                  border: "none",
+                  padding: 0,
+                  color: enabled
+                    ? theme.colors.text.main
+                    : theme.colors.text.muted,
+                  display: "flex",
+                  alignItems: "center",
+                }}
+              >
+                <Icon size={20}>{enabled ? "sensors" : "sensors_off"}</Icon>
+              </button>
             </span>
-          </span>
-          <span
-            css={{
-              display: "table-cell",
-              padding: "8px 4px",
-              verticalAlign: "middle",
-              color: s.motion
-                ? theme.colors.activity.on
-                : theme.colors.text.muted,
-              fontWeight: s.motion ? "bold" : "normal",
-              textAlign: "right",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {s.motion ? "liikettä" : "ei liikettä"}
-          </span>
-          <span
-            css={{
-              display: "table-cell",
-              padding: "8px 4px",
-              verticalAlign: "middle",
-              color: theme.colors.text.muted,
-              fontSize: 13,
-              textAlign: "right",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {s.motionUpdatedAt
-              ? formatDistanceToNow(new Date(s.motionUpdatedAt), {
-                  addSuffix: true,
-                  locale: fi,
-                })
-              : "—"}
-          </span>
-        </div>
-      ))}
+            <span
+              css={{
+                display: "table-cell",
+                padding: "8px 4px",
+                verticalAlign: "middle",
+              }}
+            >
+              <span css={{ fontWeight: active ? "bold" : "normal" }}>
+                {s.name}
+              </span>
+            </span>
+            <span
+              css={{
+                display: "table-cell",
+                padding: "8px 4px",
+                verticalAlign: "middle",
+                color: active
+                  ? theme.colors.activity.on
+                  : theme.colors.text.muted,
+                fontWeight: active ? "bold" : "normal",
+                textAlign: "right",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {!enabled
+                ? "pois käytöstä"
+                : s.motion
+                  ? "liikettä"
+                  : "ei liikettä"}
+            </span>
+            <span
+              css={{
+                display: "table-cell",
+                padding: "8px 4px",
+                verticalAlign: "middle",
+                color: theme.colors.text.muted,
+                fontSize: 13,
+                textAlign: "right",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {enabled && s.motionUpdatedAt
+                ? formatDistanceToNow(new Date(s.motionUpdatedAt), {
+                    addSuffix: true,
+                    locale: fi,
+                  })
+                : "—"}
+            </span>
+          </div>
+        );
+      })}
       {motionSensors.length === 0 && (
         <div css={{ display: "table-row" }}>
           <span

--- a/frontend/src/types/hue.ts
+++ b/frontend/src/types/hue.ts
@@ -8,6 +8,7 @@ export type Sensor = {
   battery?: number;
   motion?: boolean;
   motionUpdatedAt?: string;
+  motionEnabled?: boolean;
   connected: boolean;
 };
 
@@ -27,4 +28,5 @@ export type HueLiveEvent =
   | { type: "temperature"; id: string; temperature: number }
   | { type: "device_power"; deviceId: string; battery: number }
   | { type: "motion"; deviceId: string; motion: boolean; updatedAt: string }
+  | { type: "motion_enabled"; deviceId: string; enabled: boolean }
   | { type: "connectivity"; deviceId: string; connected: boolean };


### PR DESCRIPTION
## Summary
- New `POST /api/hue/toggleMotion/{deviceId}` flips `enabled` on the device's motion service via `PUT /clip/v2/resource/motion/{id}`. Temperature/light_level untouched, so a sensor can be silenced for sleep while still reporting room temperature.
- Motion view gets per-row `sensors`/`sensors_off` toggle button. Disabled rows are dimmed and labelled "pois käytöstä".
- New `motion_enabled` SSE event for live UI sync; upstream Hue eventstream parsing now emits the same event so toggles done from the Hue app propagate to HCC.

## Test plan
- [x] `cargo test` (18 backend tests, including new toggle + 404 cases)
- [x] `yarn lint`, `yarn format`, `tsc --noEmit`, `yarn build`
- [x] Live verification on real bridge: tap toggle → sensor stops reporting motion in Hue app while temperature continues; toggle from Hue app reflects in HCC within ~3s