### PR TITLE
Add daily energy summary panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { api } from "./api";
 import CurrentTime from "./components/CurrentTime";
 import EnergyDailyHistory from "./components/Energy/DailyHistory";
 import EnergyFlow from "./components/Energy/Flow";
+import EnergySummary from "./components/Energy/Summary";
 import FmiWeatherBox from "./components/FmiWeatherBox";
 import History from "./components/History";
 import Icon from "./components/Icon";
@@ -314,6 +315,7 @@ const App = () => {
                 }}
               >
                 <EnergyFlow />
+                <EnergySummary />
                 <EnergyDailyHistory />
               </div>
             )}

--- a/frontend/src/components/Energy/DailyHistory.tsx
+++ b/frontend/src/components/Energy/DailyHistory.tsx
@@ -72,9 +72,9 @@ const DailyHistory: React.FC<{ className?: string }> = ({ className }) => {
 
   const colors = {
     pv: theme.colors.activity.on,
-    battery: "#5fb3a3",
-    grid: theme.colors.pv,
-    soc: "#d65a8a",
+    battery: theme.colors.battery,
+    grid: theme.colors.grid,
+    soc: theme.colors.soc,
   };
 
   const points = readings.map((r) => ({

--- a/frontend/src/components/Energy/Flow.tsx
+++ b/frontend/src/components/Energy/Flow.tsx
@@ -88,7 +88,7 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
 
   const accent = theme.colors.activity.on;
   const battery = "#5fb3a3";
-  const homeColor = theme.colors.cool;
+  const homeColor = "#5b8fc2";
   const muted = theme.colors.text.muted;
   const idleStroke = theme.colors.text.main;
 

--- a/frontend/src/components/Energy/Flow.tsx
+++ b/frontend/src/components/Energy/Flow.tsx
@@ -86,12 +86,6 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
 
   const hasFlow = (v: number) => Math.abs(v) > 0.05;
 
-  const accent = theme.colors.activity.on;
-  const battery = "#5fb3a3";
-  const homeColor = "#5b8fc2";
-  const muted = theme.colors.text.muted;
-  const idleStroke = theme.colors.text.main;
-
   const flowBase = {
     fill: "none",
     strokeWidth: 3,
@@ -143,7 +137,7 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
         <div
           css={{
             fontSize: 12,
-            color: muted,
+            color: theme.colors.text.muted,
             whiteSpace: "nowrap",
           }}
         >
@@ -158,14 +152,14 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
         {/* PV → Inverter */}
         <path
           d="M160,110 C260,110 300,210 400,210"
-          stroke={accent}
+          stroke={theme.colors.activity.on}
           opacity={pvActive ? 1 : 0.3}
           css={[flowBase, pvActive && flowAnim]}
         />
         {/* Battery ↔ Inverter */}
         <path
           d="M160,310 C260,310 300,210 400,210"
-          stroke={battery}
+          stroke={theme.colors.battery}
           opacity={batteryActive ? 1 : 0.3}
           css={[
             flowBase,
@@ -176,7 +170,7 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
         {/* Inverter ↔ Grid */}
         <path
           d="M400,210 C500,210 540,110 640,110"
-          stroke={accent}
+          stroke={theme.colors.activity.on}
           opacity={gridActive ? 1 : 0.3}
           css={[
             flowBase,
@@ -187,7 +181,7 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
         {/* Inverter → Home */}
         <path
           d="M400,210 C500,210 540,310 640,310"
-          stroke={homeColor}
+          stroke={theme.colors.home}
           opacity={homeActive ? 1 : 0.3}
           css={[flowBase, homeActive && flowAnim]}
         />
@@ -199,10 +193,16 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
             cy="110"
             r="36"
             fill={theme.colors.background.light}
-            stroke={accent}
+            stroke={theme.colors.activity.on}
             strokeWidth="2"
           />
-          <NodeIcon cx={160} cy={110} size={32} color={accent} icon={Sun} />
+          <NodeIcon
+            cx={160}
+            cy={110}
+            size={32}
+            color={theme.colors.activity.on}
+            icon={Sun}
+          />
         </g>
         <text
           x="160"
@@ -214,7 +214,13 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
         >
           aurinko
         </text>
-        <text x="160" y="60" textAnchor="middle" fontSize="16" fill={muted}>
+        <text
+          x="160"
+          y="60"
+          textAnchor="middle"
+          fontSize="16"
+          fill={theme.colors.text.muted}
+        >
           tänään {data.today_energy.toFixed(1)} {data.today_energy_unit}
         </text>
         <text
@@ -235,14 +241,14 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
             cy="210"
             r="32"
             fill={theme.colors.background.light}
-            stroke={idleStroke}
+            stroke={theme.colors.text.main}
             strokeWidth="2"
           />
           <NodeIcon
             cx={400}
             cy={210}
             size={28}
-            color={idleStroke}
+            color={theme.colors.text.main}
             icon={Activity}
           />
         </g>
@@ -266,14 +272,14 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
                 cy="310"
                 r="36"
                 fill={theme.colors.background.light}
-                stroke={battery}
+                stroke={theme.colors.battery}
                 strokeWidth="2"
               />
               <NodeIcon
                 cx={160}
                 cy={310}
                 size={32}
-                color={battery}
+                color={theme.colors.battery}
                 icon={batteryIcon(soc, charging > 0)}
               />
             </g>
@@ -292,7 +298,7 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
               y="397"
               textAnchor="middle"
               fontSize="16"
-              fill={muted}
+              fill={theme.colors.text.muted}
             >
               {Math.round(soc)}%
               {charging > 0
@@ -321,10 +327,16 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
             cy="110"
             r="36"
             fill={theme.colors.background.light}
-            stroke={accent}
+            stroke={theme.colors.activity.on}
             strokeWidth="2"
           />
-          <NodeIcon cx={640} cy={110} size={30} color={accent} icon={Plug} />
+          <NodeIcon
+            cx={640}
+            cy={110}
+            size={30}
+            color={theme.colors.activity.on}
+            icon={Plug}
+          />
         </g>
         <text
           x="640"
@@ -336,7 +348,13 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
         >
           verkko
         </text>
-        <text x="640" y="60" textAnchor="middle" fontSize="16" fill={muted}>
+        <text
+          x="640"
+          y="60"
+          textAnchor="middle"
+          fontSize="16"
+          fill={theme.colors.text.muted}
+        >
           {importing > 0 ? "tuonti" : exporting > 0 ? "vienti" : "lepotila"}
         </text>
         <text
@@ -357,14 +375,14 @@ const Flow: React.FC<{ className?: string }> = ({ className }) => {
             cy="310"
             r="36"
             fill={theme.colors.background.light}
-            stroke={homeColor}
+            stroke={theme.colors.home}
             strokeWidth="2"
           />
           <NodeIcon
             cx={640}
             cy={310}
             size={30}
-            color={homeColor}
+            color={theme.colors.home}
             icon={House}
           />
         </g>

--- a/frontend/src/components/Energy/Summary.tsx
+++ b/frontend/src/components/Energy/Summary.tsx
@@ -1,0 +1,318 @@
+import { useTheme } from "@emotion/react";
+import { memo, useEffect, useState } from "react";
+import useSWR from "swr";
+
+import { api, fetcher } from "../../api";
+import { SolisData, SolisReading } from "../../types/solis";
+
+type Aggregates = {
+  exportKwh: number;
+  importKwh: number;
+  chargeKwh: number;
+  dischargeKwh: number;
+};
+
+const isSameDay = (a: Date, b: Date) =>
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate();
+
+const integrate = (readings: SolisReading[]): Aggregates => {
+  let exportKwh = 0;
+  let importKwh = 0;
+  let chargeKwh = 0;
+  let dischargeKwh = 0;
+
+  const today = new Date();
+  const todays = readings.filter((r) =>
+    isSameDay(new Date(r.recordedAt), today),
+  );
+
+  for (let i = 1; i < todays.length; i++) {
+    const a = todays[i - 1];
+    const b = todays[i];
+    const dtH =
+      (new Date(b.recordedAt).getTime() - new Date(a.recordedAt).getTime()) /
+      3_600_000;
+    if (dtH <= 0 || dtH > 1) continue; // skip large gaps (>1h)
+
+    const ag = a.gridPower ?? 0;
+    const bg = b.gridPower ?? 0;
+    exportKwh += ((Math.max(0, ag) + Math.max(0, bg)) / 2) * dtH;
+    importKwh += ((Math.max(0, -ag) + Math.max(0, -bg)) / 2) * dtH;
+
+    const ab = a.batteryPower ?? 0;
+    const bb = b.batteryPower ?? 0;
+    chargeKwh += ((Math.max(0, ab) + Math.max(0, bb)) / 2) * dtH;
+    dischargeKwh += ((Math.max(0, -ab) + Math.max(0, -bb)) / 2) * dtH;
+  }
+
+  return { exportKwh, importKwh, chargeKwh, dischargeKwh };
+};
+
+const Summary: React.FC<{ className?: string }> = ({ className }) => {
+  const theme = useTheme();
+  const { data: live } = useSWR<SolisData>(api("/api/solis"), fetcher, {
+    refreshInterval: 60_000,
+    refreshWhenHidden: true,
+    shouldRetryOnError: false,
+  });
+  const [readings, setReadings] = useState<SolisReading[]>([]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(api("/api/history/solis?hours=24"), { signal: controller.signal })
+      .then((r) => r.json())
+      .then((data: SolisReading[]) => setReadings(data))
+      .catch((err) => {
+        if (err.name !== "AbortError") setReadings([]);
+      });
+    return () => controller.abort();
+  }, []);
+
+  if (!live) return null;
+
+  const { exportKwh, importKwh, chargeKwh, dischargeKwh } = integrate(readings);
+
+  const pvTotal = live.today_energy;
+  const pvToGrid = Math.min(pvTotal, exportKwh);
+  const pvToHome = Math.max(0, pvTotal - pvToGrid);
+  const homeKwh = pvToHome + dischargeKwh + importKwh;
+
+  const homePct = pvTotal > 0 ? Math.round((pvToHome / pvTotal) * 100) : 0;
+  const gridPct = pvTotal > 0 ? 100 - homePct : 0;
+
+  const accent = theme.colors.activity.on;
+  const battery = "#5fb3a3";
+  const homeColor = theme.colors.cool;
+  const muted = theme.colors.text.muted;
+
+  // Donut geometry (viewBox 100x100, r=38)
+  const r = 38;
+  const C = 2 * Math.PI * r;
+  const homeLen = (homePct / 100) * C;
+  const gridLen = (gridPct / 100) * C;
+
+  const metrics: [string, string, string][] = [
+    ["päivän tuotto", `${pvTotal.toFixed(1)} kWh`, accent],
+    ["kulutus", `${homeKwh.toFixed(1)} kWh`, homeColor],
+    ["lataus", `${chargeKwh.toFixed(1)} kWh`, battery],
+    ["purkaus", `${dischargeKwh.toFixed(1)} kWh`, battery],
+    ["vienti", `${exportKwh.toFixed(1)} kWh`, accent],
+    ["tuonti", `${importKwh.toFixed(1)} kWh`, muted],
+  ];
+
+  return (
+    <div
+      className={className}
+      css={{
+        backgroundColor: theme.colors.background.main,
+        boxShadow: theme.shadows.main,
+        borderRadius: theme.border.radius,
+        padding: "1.25em 1.5em",
+      }}
+    >
+      <div
+        css={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          marginBottom: "1em",
+          gap: 16,
+        }}
+      >
+        <div
+          css={{
+            fontFamily: theme.fonts.heading,
+            fontSize: 18,
+          }}
+        >
+          päivän yhteenveto
+        </div>
+      </div>
+      <div
+        css={{
+          display: "grid",
+          gridTemplateColumns: "180px 1fr",
+          gap: 24,
+          alignItems: "center",
+          "@media (max-width: 600px)": {
+            gridTemplateColumns: "1fr",
+            gap: 16,
+          },
+        }}
+      >
+        <div
+          css={{
+            position: "relative",
+            width: 160,
+            height: 160,
+            margin: "0 auto",
+          }}
+        >
+          <svg
+            viewBox="0 0 100 100"
+            css={{
+              width: "100%",
+              height: "100%",
+              transform: "rotate(-90deg)",
+            }}
+          >
+            <circle
+              cx="50"
+              cy="50"
+              r={r}
+              fill="none"
+              stroke={theme.colors.background.light}
+              strokeWidth="9"
+            />
+            {pvTotal > 0 && (
+              <>
+                <circle
+                  cx="50"
+                  cy="50"
+                  r={r}
+                  fill="none"
+                  stroke={homeColor}
+                  strokeWidth="9"
+                  strokeDasharray={`${homeLen} ${C}`}
+                />
+                <circle
+                  cx="50"
+                  cy="50"
+                  r={r}
+                  fill="none"
+                  stroke={accent}
+                  strokeWidth="9"
+                  strokeDasharray={`${gridLen} ${C}`}
+                  strokeDashoffset={-homeLen}
+                />
+              </>
+            )}
+          </svg>
+          <div
+            css={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <div css={{ fontSize: 12, color: muted }}>tuotto</div>
+            <div
+              css={{
+                fontSize: 22,
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
+              {pvTotal.toFixed(1)} kWh
+            </div>
+          </div>
+        </div>
+
+        <div
+          css={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 4,
+          }}
+        >
+          <LegendRow
+            color={homeColor}
+            label="kulutukseen"
+            value={`${pvToHome.toFixed(1)} kWh`}
+            pct={homePct}
+          />
+          <LegendRow
+            color={accent}
+            label="verkkoon"
+            value={`${pvToGrid.toFixed(1)} kWh`}
+            pct={gridPct}
+          />
+          <div
+            css={{
+              display: "grid",
+              gridTemplateColumns: "repeat(2, 1fr)",
+              gap: "6px 24px",
+              paddingTop: 12,
+              marginTop: 8,
+              borderTop: `1px solid ${theme.colors.border}`,
+              fontSize: 13,
+            }}
+          >
+            {metrics.map(([k, v, c]) => (
+              <div
+                key={k}
+                css={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  gap: 8,
+                }}
+              >
+                <span css={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <span
+                    css={{
+                      display: "inline-block",
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      backgroundColor: c,
+                    }}
+                  />
+                  <span css={{ color: muted }}>{k}</span>
+                </span>
+                <span css={{ fontVariantNumeric: "tabular-nums" }}>{v}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const LegendRow: React.FC<{
+  color: string;
+  label: string;
+  value: string;
+  pct: number;
+}> = ({ color, label, value, pct }) => {
+  const theme = useTheme();
+  return (
+    <div
+      css={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        fontSize: 13,
+      }}
+    >
+      <span
+        css={{
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          backgroundColor: color,
+        }}
+      />
+      <span css={{ color: theme.colors.text.muted, minWidth: 110 }}>
+        pv → {label}
+      </span>
+      <span css={{ fontVariantNumeric: "tabular-nums" }}>{value}</span>
+      <span
+        css={{
+          color: theme.colors.text.muted,
+          marginLeft: "auto",
+          fontSize: 12,
+        }}
+      >
+        {pct}%
+      </span>
+    </div>
+  );
+};
+
+export default memo(Summary);

--- a/frontend/src/components/Energy/Summary.tsx
+++ b/frontend/src/components/Energy/Summary.tsx
@@ -74,30 +74,35 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
 
   const { exportKwh, importKwh, chargeKwh, dischargeKwh } = integrate(readings);
 
-  const pvTotal = live.today_energy;
-  const pvToGrid = Math.min(pvTotal, exportKwh);
-  const pvToHome = Math.max(0, pvTotal - pvToGrid);
-  const homeKwh = pvToHome + dischargeKwh + importKwh;
-
-  const homePct = pvTotal > 0 ? Math.round((pvToHome / pvTotal) * 100) : 0;
-  const gridPct = pvTotal > 0 ? 100 - homePct : 0;
-
   const accent = theme.colors.activity.on;
   const battery = "#5fb3a3";
-  const homeColor = theme.colors.cool;
+  const homeColor = "#5b8fc2";
   const muted = theme.colors.text.muted;
+
+  const pvTotal = live.today_energy;
+  const pvToGrid = Math.min(pvTotal, exportKwh);
+  const pvToBattery = Math.max(0, Math.min(pvTotal - pvToGrid, chargeKwh));
+  const pvToHome = Math.max(0, pvTotal - pvToGrid - pvToBattery);
+  const homeKwh = pvToHome + dischargeKwh + importKwh;
+
+  const pct = (v: number) =>
+    pvTotal > 0 ? Math.round((v / pvTotal) * 100) : 0;
+  const homePct = pct(pvToHome);
+  const batteryPct = pct(pvToBattery);
+  const gridPct = pvTotal > 0 ? 100 - homePct - batteryPct : 0;
 
   // Donut geometry (viewBox 100x100, r=38)
   const r = 38;
   const C = 2 * Math.PI * r;
   const homeLen = (homePct / 100) * C;
+  const batteryLen = (batteryPct / 100) * C;
   const gridLen = (gridPct / 100) * C;
 
   const metrics: [string, string, string][] = [
     ["päivän tuotto", `${pvTotal.toFixed(1)} kWh`, accent],
     ["kulutus", `${homeKwh.toFixed(1)} kWh`, homeColor],
     ["lataus", `${chargeKwh.toFixed(1)} kWh`, battery],
-    ["purkaus", `${dischargeKwh.toFixed(1)} kWh`, battery],
+    ["käyttö", `${dischargeKwh.toFixed(1)} kWh`, battery],
     ["vienti", `${exportKwh.toFixed(1)} kWh`, accent],
     ["tuonti", `${importKwh.toFixed(1)} kWh`, muted],
   ];
@@ -182,10 +187,20 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
                   cy="50"
                   r={r}
                   fill="none"
+                  stroke={battery}
+                  strokeWidth="9"
+                  strokeDasharray={`${batteryLen} ${C}`}
+                  strokeDashoffset={-homeLen}
+                />
+                <circle
+                  cx="50"
+                  cy="50"
+                  r={r}
+                  fill="none"
                   stroke={accent}
                   strokeWidth="9"
                   strokeDasharray={`${gridLen} ${C}`}
-                  strokeDashoffset={-homeLen}
+                  strokeDashoffset={-(homeLen + batteryLen)}
                 />
               </>
             )}
@@ -193,18 +208,21 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
           <div
             css={{
               position: "absolute",
-              inset: 0,
+              inset: 32,
               display: "flex",
               flexDirection: "column",
               alignItems: "center",
               justifyContent: "center",
+              gap: 2,
             }}
           >
             <div css={{ fontSize: 12, color: muted }}>tuotto</div>
             <div
               css={{
-                fontSize: 22,
+                fontSize: 20,
+                lineHeight: 1,
                 fontVariantNumeric: "tabular-nums",
+                whiteSpace: "nowrap",
               }}
             >
               {pvTotal.toFixed(1)} kWh
@@ -224,6 +242,12 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
             label="kulutukseen"
             value={`${pvToHome.toFixed(1)} kWh`}
             pct={homePct}
+          />
+          <LegendRow
+            color={battery}
+            label="akkuun"
+            value={`${pvToBattery.toFixed(1)} kWh`}
+            pct={batteryPct}
           />
           <LegendRow
             color={accent}

--- a/frontend/src/components/Energy/Summary.tsx
+++ b/frontend/src/components/Energy/Summary.tsx
@@ -74,11 +74,6 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
 
   const { exportKwh, importKwh, chargeKwh, dischargeKwh } = integrate(readings);
 
-  const accent = theme.colors.activity.on;
-  const battery = "#5fb3a3";
-  const homeColor = "#5b8fc2";
-  const muted = theme.colors.text.muted;
-
   const pvTotal = live.today_energy;
   const pvToGrid = Math.min(pvTotal, exportKwh);
   const pvToBattery = Math.max(0, Math.min(pvTotal - pvToGrid, chargeKwh));
@@ -99,12 +94,12 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
   const gridLen = (gridPct / 100) * C;
 
   const metrics: [string, string, string][] = [
-    ["päivän tuotto", `${pvTotal.toFixed(1)} kWh`, accent],
-    ["kulutus", `${homeKwh.toFixed(1)} kWh`, homeColor],
-    ["lataus", `${chargeKwh.toFixed(1)} kWh`, battery],
-    ["käyttö", `${dischargeKwh.toFixed(1)} kWh`, battery],
-    ["vienti", `${exportKwh.toFixed(1)} kWh`, accent],
-    ["tuonti", `${importKwh.toFixed(1)} kWh`, muted],
+    ["päivän tuotto", `${pvTotal.toFixed(1)} kWh`, theme.colors.activity.on],
+    ["kulutus", `${homeKwh.toFixed(1)} kWh`, theme.colors.home],
+    ["lataus", `${chargeKwh.toFixed(1)} kWh`, theme.colors.battery],
+    ["käyttö", `${dischargeKwh.toFixed(1)} kWh`, theme.colors.battery],
+    ["vienti", `${exportKwh.toFixed(1)} kWh`, theme.colors.activity.on],
+    ["tuonti", `${importKwh.toFixed(1)} kWh`, theme.colors.text.muted],
   ];
 
   return (
@@ -178,7 +173,7 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
                   cy="50"
                   r={r}
                   fill="none"
-                  stroke={homeColor}
+                  stroke={theme.colors.home}
                   strokeWidth="9"
                   strokeDasharray={`${homeLen} ${C}`}
                 />
@@ -187,7 +182,7 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
                   cy="50"
                   r={r}
                   fill="none"
-                  stroke={battery}
+                  stroke={theme.colors.battery}
                   strokeWidth="9"
                   strokeDasharray={`${batteryLen} ${C}`}
                   strokeDashoffset={-homeLen}
@@ -197,7 +192,7 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
                   cy="50"
                   r={r}
                   fill="none"
-                  stroke={accent}
+                  stroke={theme.colors.activity.on}
                   strokeWidth="9"
                   strokeDasharray={`${gridLen} ${C}`}
                   strokeDashoffset={-(homeLen + batteryLen)}
@@ -216,7 +211,9 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
               gap: 2,
             }}
           >
-            <div css={{ fontSize: 12, color: muted }}>tuotto</div>
+            <div css={{ fontSize: 12, color: theme.colors.text.muted }}>
+              tuotto
+            </div>
             <div
               css={{
                 fontSize: 20,
@@ -238,19 +235,19 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
           }}
         >
           <LegendRow
-            color={homeColor}
+            color={theme.colors.home}
             label="kulutukseen"
             value={`${pvToHome.toFixed(1)} kWh`}
             pct={homePct}
           />
           <LegendRow
-            color={battery}
+            color={theme.colors.battery}
             label="akkuun"
             value={`${pvToBattery.toFixed(1)} kWh`}
             pct={batteryPct}
           />
           <LegendRow
-            color={accent}
+            color={theme.colors.activity.on}
             label="verkkoon"
             value={`${pvToGrid.toFixed(1)} kWh`}
             pct={gridPct}
@@ -286,7 +283,7 @@ const Summary: React.FC<{ className?: string }> = ({ className }) => {
                       backgroundColor: c,
                     }}
                   />
-                  <span css={{ color: muted }}>{k}</span>
+                  <span css={{ color: theme.colors.text.muted }}>{k}</span>
                 </span>
                 <span css={{ fontVariantNumeric: "tabular-nums" }}>{v}</span>
               </div>

--- a/frontend/src/themes.ts
+++ b/frontend/src/themes.ts
@@ -41,6 +41,10 @@ declare module "@emotion/react" {
       cool: string;
       rain: string;
       pv: string;
+      battery: string;
+      home: string;
+      grid: string;
+      soc: string;
     };
     typography: {
       h1: Typography;
@@ -102,6 +106,10 @@ export const lightTheme: Theme = {
     cool: "#1565c0",
     rain: "#94daf7",
     pv: "#f5a524",
+    battery: "#5fb3a3",
+    home: "#5b8fc2",
+    grid: "#f5a524",
+    soc: "#d65a8a",
   },
   typography,
   shadows: {
@@ -138,6 +146,10 @@ export const darkTheme: Theme = {
     cool: "#42a5f5",
     rain: "#43529c",
     pv: "#a35a00",
+    battery: "#5fb3a3",
+    home: "#7aa3d1",
+    grid: "#f5a524",
+    soc: "#d65a8a",
   },
   typography,
   shadows: {


### PR DESCRIPTION
## Summary

- New `Energy/Summary.tsx` panel between flow diagram and daily history chart.
- Three-arc donut splits today's PV production into `kulutukseen` (home), `akkuun` (battery charge), `verkkoon` (grid export).
- Metric grid: `päivän tuotto`, `kulutus`, `lataus`, `käyttö`, `vienti`, `tuonti`.
- Soften home blue from `theme.colors.cool` (#1565c0) to `#5b8fc2` for both summary and flow diagram.

## Data

- `pvTotal` from `/api/solis` `today_energy` (authoritative).
- Aggregates from `/api/history/solis?hours=24`, filtered to today's calendar day, trapezoidal integration with >1h gaps skipped.
- `pvToGrid` clamped to `pvTotal`. `pvToBattery = chargeKwh` (assumes battery charges from PV when sun shining). `pvToHome = pvTotal − pvToGrid − pvToBattery`.

## Test plan

- [ ] Energy view: donut renders three arcs that sum to 100% when `today_energy` > 0.
- [ ] Center text `tuotto` + kWh stays inside the wheel without touching strokes.
- [ ] Legend rows + metric grid update with live data.
- [ ] Mobile: donut stacks above metrics, single column.
- [ ] Empty / cold state (no history yet, `today_energy = 0`): only background ring renders, metrics show `0.0 kWh`.