### PR TITLE
Track GitHub Actions versions via Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -27,3 +27,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds the github-actions ecosystem to .github/dependabot.yaml so workflow action versions get weekly PRs alongside npm and cargo.