### PR TITLE
Long-press to dim light groups

### DIFF
--- a/backend/src/hue/data.rs
+++ b/backend/src/hue/data.rs
@@ -151,7 +151,10 @@ async fn fetch_from_bridge(state: &Arc<AppState>) -> Result<HueResponse, HueErro
                 .get(gl.owner.rid.as_str())
                 .map(|r| r.metadata.name.clone())
                 .unwrap_or_else(|| gl.id.clone()),
-            state: GroupState { on: gl.on.on },
+            state: GroupState {
+                on: gl.on.on,
+                brightness: gl.dimming.as_ref().map(|d| d.brightness),
+            },
         })
         .collect();
 

--- a/backend/src/hue/events.rs
+++ b/backend/src/hue/events.rs
@@ -14,7 +14,10 @@ use super::discovery::get_bridge_address;
 pub enum HueLiveEvent {
     GroupedLight {
         id: String,
-        on: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        on: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        brightness: Option<f64>,
     },
     Temperature {
         id: String,
@@ -127,18 +130,27 @@ fn parse_resource_update(resource: &serde_json::Value) -> Vec<HueLiveEvent> {
         return Vec::new();
     };
     match rtype {
-        "grouped_light" => resource
-            .get("on")
-            .and_then(|o| o.get("on"))
-            .and_then(|o| o.as_bool())
-            .zip(resource.get("id").and_then(|v| v.as_str()))
-            .map(|(on, id)| {
-                vec![HueLiveEvent::GroupedLight {
-                    id: id.to_string(),
-                    on,
-                }]
-            })
-            .unwrap_or_default(),
+        "grouped_light" => {
+            let Some(id) = resource.get("id").and_then(|v| v.as_str()) else {
+                return Vec::new();
+            };
+            let on = resource
+                .get("on")
+                .and_then(|o| o.get("on"))
+                .and_then(|o| o.as_bool());
+            let brightness = resource
+                .get("dimming")
+                .and_then(|d| d.get("brightness"))
+                .and_then(|b| b.as_f64());
+            if on.is_none() && brightness.is_none() {
+                return Vec::new();
+            }
+            vec![HueLiveEvent::GroupedLight {
+                id: id.to_string(),
+                on,
+                brightness,
+            }]
+        }
         "temperature" => resource
             .get("temperature")
             .and_then(|temp_obj| {

--- a/backend/src/hue/handlers.rs
+++ b/backend/src/hue/handlers.rs
@@ -204,6 +204,64 @@ pub async fn toggle_group(
     }
 }
 
+// ---- POST /api/hue/setBrightness/{id} ----
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SetBrightnessRequest {
+    /// Target brightness percentage (0..=100). 0 turns the group off.
+    pub brightness: f64,
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/hue/setBrightness/{id}",
+    params(("id" = String, Path, description = "Grouped light resource ID")),
+    request_body = SetBrightnessRequest,
+    responses(
+        (status = 200, description = "Brightness set"),
+        (status = 400, description = "Invalid brightness"),
+        (status = 502, description = "Failed to set brightness")
+    )
+)]
+pub async fn set_brightness(
+    state: web::Data<Arc<AppState>>,
+    path: web::Path<String>,
+    body: web::Json<SetBrightnessRequest>,
+) -> HttpResponse {
+    let group_id = path.into_inner();
+    let brightness = body.brightness;
+
+    if !(0.0..=100.0).contains(&brightness) || brightness.is_nan() {
+        return HttpResponse::BadRequest()
+            .json(serde_json::json!({"error": "brightness must be 0..=100"}));
+    }
+
+    // Hue rejects dimming.brightness == 0; use on:false for that case.
+    // Otherwise force on:true so dragging from 0 also turns the group on.
+    let payload = if brightness <= 0.0 {
+        serde_json::json!({"on": {"on": false}})
+    } else {
+        serde_json::json!({
+            "on": {"on": true},
+            "dimming": {"brightness": brightness},
+        })
+    };
+
+    match hue_put(
+        &state,
+        &format!("/clip/v2/resource/grouped_light/{group_id}"),
+        &payload,
+    )
+    .await
+    {
+        Ok(()) => HttpResponse::Ok().finish(),
+        Err(e) => {
+            tracing::error!("Failed to set brightness for {group_id}: {e}");
+            HttpResponse::BadGateway().json(serde_json::json!({"error": e.to_string()}))
+        }
+    }
+}
+
 // ---- POST /api/hue/toggleMotion/{deviceId} ----
 
 #[utoipa::path(

--- a/backend/src/hue/models.rs
+++ b/backend/src/hue/models.rs
@@ -41,6 +41,9 @@ pub struct Group {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GroupState {
     pub on: bool,
+    /// Brightness percentage (0..=100). Hue reports it independently of `on`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub brightness: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -106,6 +109,12 @@ pub struct GroupedLightResource {
     pub id: String,
     pub owner: GroupedLightOwner,
     pub on: OnState,
+    pub dimming: Option<DimmingState>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DimmingState {
+    pub brightness: f64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -40,6 +40,7 @@ pub struct AppState {
         hue::handlers::events_sse,
         hue::handlers::pair,
         hue::handlers::toggle_group,
+        hue::handlers::set_brightness,
         hue::handlers::toggle_motion,
         solis::handlers::get_data,
         solis::handlers::get_history,
@@ -57,6 +58,7 @@ pub struct AppState {
         hue::events::HueLiveEvent,
         hue::handlers::PairRequest,
         hue::handlers::PairResponse,
+        hue::handlers::SetBrightnessRequest,
         solis::models::SolisWidgetData,
         solis::models::SolisReading,
         pv::models::PvForecast,
@@ -192,6 +194,10 @@ pub fn create_app(
                         .route(
                             "/toggleGroup/{id}",
                             web::post().to(hue::handlers::toggle_group),
+                        )
+                        .route(
+                            "/setBrightness/{id}",
+                            web::post().to(hue::handlers::set_brightness),
                         )
                         .route(
                             "/toggleMotion/{deviceId}",

--- a/backend/tests/smoke.rs
+++ b/backend/tests/smoke.rs
@@ -272,7 +272,10 @@ async fn hue_get_returns_cached_data() {
         groups: vec![hue::models::Group {
             id: "g1".into(),
             name: "Living Room".into(),
-            state: hue::models::GroupState { on: true },
+            state: hue::models::GroupState {
+                on: true,
+                brightness: Some(80.0),
+            },
         }],
     };
     state.hue_cache.set("hue".to_owned(), cached).await;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,7 +24,15 @@ const applyEvent = (data: Response, event: HueLiveEvent): Response => {
       return {
         ...data,
         groups: data.groups.map((g) =>
-          g.id === event.id ? { ...g, state: { on: event.on } } : g,
+          g.id === event.id
+            ? {
+                ...g,
+                state: {
+                  on: event.on ?? g.state.on,
+                  brightness: event.brightness ?? g.state.brightness,
+                },
+              }
+            : g,
         ),
       };
     case "temperature":

--- a/frontend/src/components/LightGroups.tsx
+++ b/frontend/src/components/LightGroups.tsx
@@ -1,5 +1,5 @@
 import { keyframes, useTheme } from "@emotion/react";
-import { FC, memo, useCallback, useState } from "react";
+import { FC, memo, PointerEvent, useCallback, useRef, useState } from "react";
 
 import { api } from "../api";
 import useScreenshotMode, { anonymize } from "../hooks/useScreenshotMode";
@@ -11,6 +11,13 @@ const bulbGlow = keyframes`
   0%, 100% { filter: drop-shadow(0 0 4px rgba(247, 143, 8, 0.55)); }
   50%      { filter: drop-shadow(0 0 10px rgba(247, 143, 8, 0.85)); }
 `;
+
+const LONG_PRESS_MS = 350;
+const MOVE_CANCEL_PX = 8;
+const LIVE_THROTTLE_MS = 200;
+
+const clamp = (v: number, lo: number, hi: number) =>
+  Math.min(hi, Math.max(lo, v));
 
 type LightGroupsProps = {
   groups: Group[];
@@ -51,34 +58,158 @@ type LightGroupProps = {
 const LightGroup: FC<LightGroupProps> = ({ group }) => {
   const [isOn, setIsOn] = useState(group.state.on);
   const [prevOn, setPrevOn] = useState(group.state.on);
+  const [brightness, setBrightness] = useState(group.state.brightness ?? 100);
+  const [prevBrightness, setPrevBrightness] = useState(
+    group.state.brightness ?? 100,
+  );
+  const [dimming, setDimming] = useState(false);
 
+  // Sync from props (live SSE updates).
   if (prevOn !== group.state.on) {
     setPrevOn(group.state.on);
-    setIsOn(group.state.on);
+    if (!dimming) setIsOn(group.state.on);
+  }
+  const incomingBrightness = group.state.brightness ?? 100;
+  if (prevBrightness !== incomingBrightness) {
+    setPrevBrightness(incomingBrightness);
+    if (!dimming) setBrightness(incomingBrightness);
   }
 
-  const handleClick = useCallback(
-    (id: string, on: boolean) => () => {
-      fetch(api(`/api/hue/toggleGroup/${id}`), { method: "POST" }).then(
-        (res) => {
-          if (res.status === 200) {
-            setIsOn(!on);
-          }
-        },
-      );
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const longPressTimerRef = useRef<number | null>(null);
+  const dragStartRef = useRef<{
+    x: number;
+    y: number;
+    brightness: number;
+  } | null>(null);
+  const skipClickRef = useRef(false);
+  const lastSentRef = useRef(0);
+
+  const sendBrightness = useCallback(
+    (val: number) => {
+      fetch(api(`/api/hue/setBrightness/${group.id}`), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ brightness: val }),
+      });
     },
-    [],
+    [group.id],
   );
+
+  const cancelLongPress = useCallback(() => {
+    if (longPressTimerRef.current !== null) {
+      window.clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (e: PointerEvent<HTMLButtonElement>) => {
+      if (e.pointerType === "mouse" && e.button !== 0) return;
+      dragStartRef.current = {
+        x: e.clientX,
+        y: e.clientY,
+        brightness,
+      };
+      cancelLongPress();
+      longPressTimerRef.current = window.setTimeout(() => {
+        longPressTimerRef.current = null;
+        setDimming(true);
+        setIsOn(true);
+        buttonRef.current?.setPointerCapture(e.pointerId);
+      }, LONG_PRESS_MS);
+    },
+    [brightness, cancelLongPress],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent<HTMLButtonElement>) => {
+      const start = dragStartRef.current;
+      if (!start) return;
+      const dx = e.clientX - start.x;
+      const dy = e.clientY - start.y;
+
+      if (longPressTimerRef.current !== null) {
+        if (Math.abs(dx) > MOVE_CANCEL_PX || Math.abs(dy) > MOVE_CANCEL_PX) {
+          cancelLongPress();
+          dragStartRef.current = null;
+        }
+        return;
+      }
+      if (!dimming) return;
+
+      const width = buttonRef.current?.clientWidth ?? 1;
+      const next = clamp(start.brightness + (dx / width) * 100, 0, 100);
+      setBrightness(next);
+
+      const now = performance.now();
+      if (now - lastSentRef.current > LIVE_THROTTLE_MS) {
+        lastSentRef.current = now;
+        sendBrightness(next);
+      }
+    },
+    [dimming, cancelLongPress, sendBrightness],
+  );
+
+  const finishGesture = useCallback(
+    (e: PointerEvent<HTMLButtonElement>, commit: boolean) => {
+      cancelLongPress();
+      if (dimming) {
+        skipClickRef.current = true;
+        if (commit) {
+          sendBrightness(brightness);
+          setIsOn(brightness > 0);
+        }
+        setDimming(false);
+        if (buttonRef.current?.hasPointerCapture(e.pointerId)) {
+          buttonRef.current.releasePointerCapture(e.pointerId);
+        }
+      }
+      dragStartRef.current = null;
+    },
+    [brightness, cancelLongPress, dimming, sendBrightness],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: PointerEvent<HTMLButtonElement>) => finishGesture(e, true),
+    [finishGesture],
+  );
+
+  const handlePointerCancel = useCallback(
+    (e: PointerEvent<HTMLButtonElement>) => finishGesture(e, false),
+    [finishGesture],
+  );
+
+  const handleClick = useCallback(() => {
+    if (skipClickRef.current) {
+      skipClickRef.current = false;
+      return;
+    }
+    fetch(api(`/api/hue/toggleGroup/${group.id}`), { method: "POST" }).then(
+      (res) => {
+        if (res.status === 200) setIsOn((prev) => !prev);
+      },
+    );
+  }, [group.id]);
 
   const theme = useTheme();
   const demo = useScreenshotMode();
   const accent = theme.colors.activity.on;
   const muted = theme.colors.text.muted;
+  const showFill = isOn || dimming;
+  const fillWidth = showFill ? brightness : 0;
 
   return (
     <button
-      onClick={handleClick(group.id, isOn)}
+      ref={buttonRef}
+      onClick={handleClick}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
       css={{
+        position: "relative",
+        overflow: "hidden",
         display: "flex",
         flexDirection: "row",
         alignItems: "center",
@@ -89,15 +220,30 @@ const LightGroup: FC<LightGroupProps> = ({ group }) => {
         width: "100%",
         borderRadius: theme.border.radius,
         border: `3px solid ${isOn ? accent : theme.colors.text.main}`,
-        background: isOn
-          ? theme.colors.activity.onBackground
-          : theme.colors.background.light,
-        transition: "background 0.4s ease, border-color 0.3s ease",
+        background: theme.colors.background.light,
+        transition: "border-color 0.3s ease",
         textAlign: "left",
+        touchAction: "none",
+        userSelect: "none",
       }}
     >
       <div
+        aria-hidden
         css={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          bottom: 0,
+          width: `${fillWidth}%`,
+          background: theme.colors.activity.onBackground,
+          pointerEvents: "none",
+          transition: dimming ? "none" : "width 0.3s ease, opacity 0.3s ease",
+          opacity: showFill ? 1 : 0,
+        }}
+      />
+      <div
+        css={{
+          position: "relative",
           flexShrink: 0,
           display: "flex",
           justifyContent: "center",
@@ -125,6 +271,7 @@ const LightGroup: FC<LightGroupProps> = ({ group }) => {
       </div>
       <div
         css={{
+          position: "relative",
           flex: 1,
           minWidth: 0,
           display: "flex",

--- a/frontend/src/components/SolisBox.tsx
+++ b/frontend/src/components/SolisBox.tsx
@@ -90,11 +90,12 @@ const SolisBox: React.FC<SolisBoxProps> = ({ className }) => {
       >
         <div
           css={{
-            fontWeight: "normal",
-            fontSize: 18,
             display: "flex",
             alignItems: "center",
             gap: "0.3em",
+            ...theme.typography.label,
+            color: theme.colors.text.muted,
+            letterSpacing: "0.04em",
           }}
         >
           <Icon

--- a/frontend/src/types/hue.ts
+++ b/frontend/src/types/hue.ts
@@ -15,7 +15,7 @@ export type Sensor = {
 export type Group = {
   id: string;
   name: string;
-  state: { on: boolean };
+  state: { on: boolean; brightness?: number };
 };
 
 export type Response = {
@@ -24,7 +24,12 @@ export type Response = {
 };
 
 export type HueLiveEvent =
-  | { type: "grouped_light"; id: string; on: boolean }
+  | {
+      type: "grouped_light";
+      id: string;
+      on?: boolean;
+      brightness?: number;
+    }
   | { type: "temperature"; id: string; temperature: number }
   | { type: "device_power"; deviceId: string; battery: number }
   | { type: "motion"; deviceId: string; motion: boolean; updatedAt: string }


### PR DESCRIPTION
## Summary
- Long-press (350ms) on a light group toggle enters dim mode; horizontal drag fills the button background left-to-right as a brightness progress bar; release commits.
- Tap still toggles on/off. Live throttled at 200ms during drag, final commit on release.
- Backend: `GroupState.brightness` surfaced in `/api/hue` and SSE `grouped_light` events; new `POST /api/hue/setBrightness/{id}` route. brightness=0 maps to `on:false` (Hue rejects bri=0).
- Side: solis box label restyled as muted small caps to match other section labels.

## Test plan
- [ ] Mouse: tap toggles, long-press + drag dims with smooth fill
- [ ] Touch on wall device: tap, long-press, drag, release
- [ ] Vertical scroll near button still works (drag must move >8px before long-press fires)
- [ ] Lights respond live during drag, final value sticks on release
- [ ] Drag fully left → group turns off; drag back right → turns on
- [ ] SSE updates from physical Hue dimmer reflect in UI brightness