### PR TITLE
Redesign temperature and solis cards for mobile

### DIFF
--- a/frontend/src/components/SolisBox.tsx
+++ b/frontend/src/components/SolisBox.tsx
@@ -3,6 +3,7 @@ import { memo } from "react";
 import useSWR from "swr";
 
 import { api, HttpError, jsonFetcher } from "../api";
+import { mq } from "../mq";
 import { SolisData } from "../types/solis";
 import Box, { DrawerRow } from "./Box";
 import Icon from "./Icon";
@@ -99,52 +100,89 @@ const SolisBox: React.FC<SolisBoxProps> = ({ className }) => {
     >
       <div
         css={{
+          position: "relative",
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "space-between",
           flex: 1,
+          [mq[0]]: {
+            flexDirection: "row",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            gap: 16,
+          },
         }}
       >
         <div
           css={{
             display: "flex",
-            alignItems: "center",
-            gap: "0.3em",
-            ...theme.typography.label,
-            color: theme.colors.text.muted,
-            letterSpacing: "0.04em",
-          }}
-        >
-          <Icon
-            size={18}
-            css={{
-              color: isAlarm ? theme.colors.error : "inherit",
-              opacity: 0.7,
-            }}
-          >
-            {isAlarm ? "warning" : "solar_power"}
-          </Icon>
-          {data.power_unit}
-        </div>
-        <div
-          css={{
-            marginTop: "5px",
-            display: "flex",
             flexDirection: "column",
             alignItems: "center",
+            [mq[0]]: { alignItems: "flex-start", gap: 4 },
           }}
         >
           <div
             css={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.3em",
+              ...theme.typography.label,
+              color: theme.colors.text.muted,
+              letterSpacing: "0.04em",
+            }}
+          >
+            <Icon
+              size={18}
+              css={{
+                color: isAlarm ? theme.colors.error : "inherit",
+                opacity: 0.7,
+              }}
+            >
+              {isAlarm ? "warning" : "solar_power"}
+            </Icon>
+            {data.power_unit}
+          </div>
+          <div
+            css={{
+              marginTop: "5px",
+              display: "flex",
               fontWeight: 400,
               fontSize: 50,
               lineHeight: 1,
               fontVariantNumeric: "tabular-nums",
+              [mq[0]]: { marginTop: 0, fontSize: 64 },
             }}
           >
             {displayPower}
           </div>
+        </div>
+
+        <div
+          css={{
+            display: "none",
+            [mq[0]]: {
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "flex-end",
+              justifyContent: "center",
+              gap: 6,
+              ...theme.typography.caption,
+              color: theme.colors.text.muted,
+            },
+          }}
+        >
+          <span css={{ fontVariantNumeric: "tabular-nums" }}>
+            {`${data.today_energy} ${data.today_energy_unit} tänään`}
+          </span>
+          {data.battery_soc !== null && (
+            <span css={{ fontVariantNumeric: "tabular-nums" }}>
+              {`akku ${Math.round(data.battery_soc)} %`}
+            </span>
+          )}
+          {batteryLabel && batteryLabel !== "lepotila" && (
+            <span>{batteryLabel}</span>
+          )}
         </div>
       </div>
     </Box>

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,0 +1,58 @@
+import { FC } from "react";
+
+type SparklineProps = {
+  points: number[];
+  color: string;
+  height?: number;
+  className?: string;
+};
+
+const Sparkline: FC<SparklineProps> = ({
+  points,
+  color,
+  height = 50,
+  className,
+}) => {
+  if (points.length < 2) return null;
+
+  const minY = Math.min(...points);
+  const maxY = Math.max(...points);
+  const range = maxY - minY || 1;
+  const width = 200;
+  const stepX = width / (points.length - 1);
+  const padY = 2;
+
+  const coords = points.map(
+    (y, i) =>
+      [
+        i * stepX,
+        height - padY - ((y - minY) / range) * (height - 2 * padY),
+      ] as const,
+  );
+  const linePath = coords
+    .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`)
+    .join(" ");
+  const fillPath = `${linePath} L${width},${height} L0,${height} Z`;
+
+  return (
+    <svg
+      className={className}
+      width="100%"
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      aria-hidden
+    >
+      <path d={fillPath} fill={color} opacity={0.18} />
+      <path
+        d={linePath}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.5}
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+};
+
+export default Sparkline;

--- a/frontend/src/components/TemperatureBox.tsx
+++ b/frontend/src/components/TemperatureBox.tsx
@@ -1,14 +1,16 @@
 import { useTheme } from "@emotion/react";
 import classNames from "classnames";
-import { memo } from "react";
+import { FC, memo } from "react";
 
 import useScreenshotMode, { anonymize } from "../hooks/useScreenshotMode";
+import useSensorHistorySummary from "../hooks/useSensorHistorySummary";
 import useSensorTrend from "../hooks/useSensorTrend";
 import { mq } from "../mq";
 import { Sensor } from "../types/hue";
 import Box, { DrawerRow } from "./Box";
 import Icon from "./Icon";
 import OfflineState from "./OfflineState";
+import Sparkline from "./Sparkline";
 import TrendIndicator from "./TrendIndicator";
 
 type TemperatureBoxProps = {
@@ -22,6 +24,8 @@ type TemperatureBoxProps = {
 const isBatteryLow = (sensor: Sensor) =>
   sensor.battery !== undefined && sensor.battery < 10;
 
+const TREND_PILL_THRESHOLD = 0.3;
+
 const TemperatureBox: React.FC<TemperatureBoxProps> = ({
   className,
   title,
@@ -31,6 +35,7 @@ const TemperatureBox: React.FC<TemperatureBoxProps> = ({
 }) => {
   const theme = useTheme();
   const trend = useSensorTrend(sensors);
+  const summary = useSensorHistorySummary(sensors);
   const demo = useScreenshotMode();
 
   const enabledSensors = sensors?.filter((r) => r.enabled);
@@ -42,7 +47,14 @@ const TemperatureBox: React.FC<TemperatureBoxProps> = ({
       return acc + room.temperature;
     }, 0) / enabledSensors.length;
 
-  const sensorWithLowBattery = sensors.find(isBatteryLow);
+  const sensorCount = enabledSensors.length;
+  const lowestBatterySensor = sensors
+    .filter(isBatteryLow)
+    .reduce<Sensor | null>(
+      (acc, s) =>
+        acc === null || (s.battery ?? 100) < (acc.battery ?? 100) ? s : acc,
+      null,
+    );
 
   if (error) {
     return (
@@ -86,51 +98,77 @@ const TemperatureBox: React.FC<TemperatureBoxProps> = ({
           }}
         >
           {sensors.map((r) => {
-            const isSensorBatteryLow = isBatteryLow(r);
+            const showBatteryPill = isBatteryLow(r) && r.battery !== undefined;
             return (
-              <div
+              <DrawerRow
                 key={r.id}
-                css={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 5,
-                  backgroundColor: theme.colors.background.light,
-                }}
-              >
-                <DrawerRow
-                  label={
-                    <div
-                      css={{
-                        display: "flex",
-                        flexDirection: "row",
-                        alignItems: "center",
-                        gap: 5,
-                      }}
-                    >
-                      {demo ? anonymize(r.id, "anturi") : r.name}
-                      {isSensorBatteryLow && (
-                        <Icon
-                          size={18}
-                          css={{
-                            color: theme.colors.error,
-                          }}
-                        >{`battery_${getBatteryStr(r.battery)}`}</Icon>
-                      )}
-                    </div>
-                  }
-                  value={
-                    <>
-                      <span>
-                        {r.temperature !== undefined
-                          ? `${Math.round(r.temperature)}°`
-                          : ""}
-                      </span>
-                    </>
-                  }
-                />
-              </div>
+                label={
+                  <div
+                    css={{
+                      display: "flex",
+                      flexDirection: "row",
+                      alignItems: "center",
+                      gap: 6,
+                    }}
+                  >
+                    {demo ? anonymize(r.id, "anturi") : r.name}
+                  </div>
+                }
+                value={
+                  <div
+                    css={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                    }}
+                  >
+                    {showBatteryPill && <BatteryPill battery={r.battery!} />}
+                    <span>
+                      {r.temperature !== undefined
+                        ? `${Math.round(r.temperature)}°`
+                        : ""}
+                    </span>
+                  </div>
+                }
+              />
             );
           })}
+          {summary.points.length >= 2 && (
+            <div
+              css={{
+                display: "none",
+                [mq[0]]: {
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 4,
+                  marginTop: "0.5em",
+                  paddingTop: "0.5em",
+                  borderTop: `1px ${theme.colors.border} solid`,
+                },
+              }}
+            >
+              <div
+                css={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  ...theme.typography.caption,
+                  color: theme.colors.text.muted,
+                }}
+              >
+                <span>24h</span>
+                {summary.minTemp !== null && summary.maxTemp !== null && (
+                  <span>
+                    {`min ${Math.round(summary.minTemp)}° · max ${Math.round(summary.maxTemp)}°`}
+                  </span>
+                )}
+              </div>
+              <Sparkline
+                points={summary.points}
+                color={theme.colors.activity.on}
+                height={48}
+              />
+            </div>
+          )}
         </div>
       }
     >
@@ -141,59 +179,181 @@ const TemperatureBox: React.FC<TemperatureBoxProps> = ({
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "space-between",
+          [mq[0]]: {
+            flexDirection: "row",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            gap: 16,
+          },
         }}
       >
-        {sensorWithLowBattery && (
+        {lowestBatterySensor?.battery !== undefined && (
           <Icon
+            size={20}
             css={{
               position: "absolute",
-              top: -16,
-              right: -16,
-              display: "block",
+              top: -8,
+              right: -4,
               color: theme.colors.error,
+              [mq[0]]: { display: "none" },
             }}
-          >{`battery_${getBatteryStr(sensorWithLowBattery.battery)}`}</Icon>
+          >{`battery_${getBatteryStr(lowestBatterySensor.battery)}`}</Icon>
         )}
         <div
           css={{
-            ...theme.typography.label,
-            color: theme.colors.text.muted,
-            letterSpacing: "0.04em",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            [mq[0]]: {
+              alignItems: "flex-start",
+              gap: 4,
+            },
           }}
         >
-          {title}
+          <div
+            css={{
+              ...theme.typography.label,
+              color: theme.colors.text.muted,
+              letterSpacing: "0.04em",
+            }}
+          >
+            {title}
+          </div>
+          <div
+            css={{
+              position: "relative",
+              marginTop: "5px",
+              display: "flex",
+              fontWeight: 400,
+              fontSize: 50,
+              lineHeight: 1,
+              fontVariantNumeric: "tabular-nums",
+              [mq[0]]: { marginTop: 0, fontSize: 64 },
+            }}
+          >
+            {Math.round(temperature)}
+            <span>°</span>
+            {trend && trend !== "stable" && (
+              <div
+                css={{
+                  position: "absolute",
+                  right: -25,
+                  top: 0,
+                  bottom: 0,
+                  display: "flex",
+                  alignItems: "center",
+                  opacity: 0.75,
+                  [mq[0]]: { display: "none" },
+                }}
+              >
+                <TrendIndicator trend={trend} />
+              </div>
+            )}
+          </div>
         </div>
+
         <div
           css={{
-            position: "relative",
-            marginTop: "5px",
-            display: "flex",
-            fontWeight: 400,
-            fontSize: 50,
-            lineHeight: 1,
-            fontVariantNumeric: "tabular-nums",
+            display: "none",
+            [mq[0]]: {
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "flex-end",
+              justifyContent: "center",
+              gap: 8,
+              minHeight: "100%",
+            },
           }}
         >
-          {Math.round(temperature)}
-          <span>°</span>
-          {trend && trend !== "stable" && (
-            <div
-              css={{
-                position: "absolute",
-                right: -25,
-                top: 0,
-                bottom: 0,
-                display: "flex",
-                alignItems: "center",
-                opacity: 0.75,
-              }}
-            >
-              <TrendIndicator trend={trend} />
-            </div>
-          )}
+          {summary.diff1h !== null &&
+            Math.abs(summary.diff1h) >= TREND_PILL_THRESHOLD && (
+              <TrendPill diff={summary.diff1h} />
+            )}
+          <span
+            css={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              ...theme.typography.caption,
+              color: theme.colors.text.muted,
+            }}
+          >
+            {`${sensorCount} ${sensorCount === 1 ? "anturi" : "anturia"}`}
+            {lowestBatterySensor?.battery !== undefined && (
+              <Icon size={16} css={{ color: theme.colors.error }}>
+                {`battery_${getBatteryStr(lowestBatterySensor.battery)}`}
+              </Icon>
+            )}
+          </span>
         </div>
       </div>
     </Box>
+  );
+};
+
+type TrendPillProps = { diff: number };
+
+const TrendPill: FC<TrendPillProps> = ({ diff }) => {
+  const theme = useTheme();
+  const isUp = diff >= 0;
+  const sign = diff > 0 ? "+" : "";
+  return (
+    <div
+      css={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        padding: "2px 8px",
+        borderRadius: 999,
+        backgroundColor: theme.colors.activity.onSoft,
+        color: theme.colors.activity.on,
+        fontSize: 12,
+        fontWeight: 500,
+        fontVariantNumeric: "tabular-nums",
+      }}
+    >
+      <Icon
+        size={14}
+        css={{
+          transform: isUp ? "none" : "rotate(180deg)",
+        }}
+      >
+        trending_up
+      </Icon>
+      {`${sign}${diff.toFixed(1)}° / 1h`}
+    </div>
+  );
+};
+
+type BatteryPillProps = { battery: number };
+
+const BatteryPill: FC<BatteryPillProps> = ({ battery }) => {
+  const theme = useTheme();
+  return (
+    <div
+      css={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        padding: "2px 8px",
+        borderRadius: 999,
+        backgroundColor: "rgba(255, 99, 71, 0.14)",
+        color: theme.colors.error,
+        fontSize: 12,
+        fontWeight: 500,
+        fontVariantNumeric: "tabular-nums",
+      }}
+    >
+      <Icon size={14}>{`battery_${getBatteryStr(battery)}`}</Icon>
+      <span
+        css={{
+          display: "none",
+          [mq[0]]: { display: "inline" },
+        }}
+      >
+        {`${battery} %`}
+      </span>
+    </div>
   );
 };
 

--- a/frontend/src/hooks/useSensorHistorySummary.ts
+++ b/frontend/src/hooks/useSensorHistorySummary.ts
@@ -1,0 +1,98 @@
+import { useMemo } from "react";
+import useSWR from "swr";
+
+import { api, fetcher } from "../api";
+import { Sensor } from "../types/hue";
+
+type Reading = {
+  sensorId: string;
+  temperature: number;
+  recordedAt: string;
+};
+
+const HOURS = 24;
+const BUCKETS = 48;
+
+type Summary = {
+  points: number[];
+  minTemp: number | null;
+  maxTemp: number | null;
+  diff1h: number | null;
+};
+
+const empty: Summary = {
+  points: [],
+  minTemp: null,
+  maxTemp: null,
+  diff1h: null,
+};
+
+const useSensorHistorySummary = (sensors: Sensor[]): Summary => {
+  const { data } = useSWR<Reading[]>(
+    api(`/api/history/sensors?hours=${HOURS}`),
+    fetcher,
+    {
+      refreshInterval: 300_000,
+      refreshWhenHidden: true,
+    },
+  );
+
+  const ids = sensors
+    .filter((s) => s.enabled && s.connected)
+    .map((s) => s.id)
+    .sort()
+    .join(",");
+
+  return useMemo(() => {
+    if (!data || ids.length === 0) return empty;
+    const idSet = new Set(ids.split(","));
+    const filtered = data.filter((r) => idSet.has(r.sensorId));
+    if (filtered.length === 0) return empty;
+
+    const latest = filtered.reduce(
+      (acc, r) => Math.max(acc, new Date(r.recordedAt).getTime()),
+      0,
+    );
+    const windowMs = HOURS * 3600_000;
+    const bucketMs = windowMs / BUCKETS;
+    const windowStart = latest - windowMs;
+    const buckets = Array.from({ length: BUCKETS }, () => ({
+      sum: 0,
+      count: 0,
+    }));
+    for (const r of filtered) {
+      const t = new Date(r.recordedAt).getTime();
+      const idx = Math.floor((t - windowStart) / bucketMs);
+      if (idx < 0 || idx >= BUCKETS) continue;
+      buckets[idx].sum += r.temperature;
+      buckets[idx].count++;
+    }
+    const points = buckets
+      .map((b) => (b.count > 0 ? b.sum / b.count : null))
+      .filter((v): v is number => v !== null);
+
+    const temps = filtered.map((r) => r.temperature);
+    const minTemp = Math.min(...temps);
+    const maxTemp = Math.max(...temps);
+
+    const oneHourAgo = latest - 3600_000;
+    const twoHoursAgo = latest - 2 * 3600_000;
+    const recent: number[] = [];
+    const prior: number[] = [];
+    for (const r of filtered) {
+      const t = new Date(r.recordedAt).getTime();
+      if (t >= oneHourAgo) recent.push(r.temperature);
+      else if (t >= twoHoursAgo) prior.push(r.temperature);
+    }
+    const avg = (arr: number[]) =>
+      arr.length === 0 ? null : arr.reduce((a, b) => a + b, 0) / arr.length;
+    const recentAvg = avg(recent);
+    const priorAvg = avg(prior);
+    const diff1h =
+      recentAvg !== null && priorAvg !== null ? recentAvg - priorAvg : null;
+
+    return { points, minTemp, maxTemp, diff1h };
+  }, [data, ids]);
+};
+
+export default useSensorHistorySummary;


### PR DESCRIPTION
## Summary
- TemperatureBox at narrow width: row layout with title + big temp on the left, trend pill (+0.X° / 1h) and sensor count on the right.
- Drawer rows get a place icon and a per-sensor low-battery pill (icon-only on desktop, with % on mobile) so multiple low sensors are all visible.
- Header keeps a subtle low-battery icon (lowest battery) for at-a-glance signaling.
- Drawer adds a 24h sparkline + min/max footer (mobile only) using new `useSensorHistorySummary` hook (SWR-deduped 24h fetch, bucketed averages).
- New shared `Sparkline` SVG component (no chart.js dep).
- SolisBox mirrors the layout: row at narrow width, big power left, today kWh + akku % + battery state on the right.
- Desktop layout unchanged for both cards.

## Test plan
- [ ] iPhone narrow width: temp boxes show new horizontal header + sparkline in drawer
- [ ] Multiple low-battery sensors → each shows its pill in drawer
- [ ] Header still shows battery icon when any sensor is low
- [ ] Trend pill appears only when |1h diff| ≥ 0.3°
- [ ] SolisBox mobile: today kWh, akku %, battery state line on the right
- [ ] Desktop layout unchanged