### PR TITLE
feat(reserve): add FCR-N reserve payout view

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,5 +12,6 @@ fi
 
 if echo "$STAGED" | grep -q "^backend/"; then
   echo "Running backend lint..."
+  (cd "$ROOT/backend" && cargo fmt --check)
   (cd "$ROOT/backend" && cargo clippy -- -D warnings)
 fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,11 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: backend
+      - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
       - run: cargo test
       - run: cargo build

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cache;
 pub mod hue;
 pub mod pv;
+pub mod reserve;
 pub mod settings;
 pub mod solis;
 pub mod storage;
@@ -46,6 +47,7 @@ pub struct AppState {
         solis::handlers::get_history,
         pv::handlers::get_forecast,
         pv::handlers::post_forecast,
+        reserve::handlers::get_reserve,
         status,
         sensor_history,
     ),
@@ -63,6 +65,8 @@ pub struct AppState {
         solis::models::SolisReading,
         pv::models::PvForecast,
         pv::models::PvPoint,
+        reserve::models::ReserveResponse,
+        reserve::models::ReservePoint,
         StatusResponse,
         storage::SensorReading,
     ))
@@ -214,6 +218,9 @@ pub fn create_app(
                             .route(web::get().to(pv::handlers::get_forecast))
                             .route(web::post().to(pv::handlers::post_forecast)),
                     ),
+                )
+                .service(
+                    web::scope("/reserve").route("", web::get().to(reserve::handlers::get_reserve)),
                 ),
         )
         .service(SwaggerUi::new("/docs/{_:.*}").url("/api-doc/openapi.json", openapi))

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -103,7 +103,11 @@ async fn sensor_history(
     query: web::Query<SensorHistoryQuery>,
 ) -> HttpResponse {
     let hours = query.hours.unwrap_or(24).min(720);
-    match state.storage.query_readings(query.sensor_id.as_deref(), hours, query.max_points).await {
+    match state
+        .storage
+        .query_readings(query.sensor_id.as_deref(), hours, query.max_points)
+        .await
+    {
         Ok(readings) => HttpResponse::Ok().json(readings),
         Err(e) => {
             tracing::error!("Failed to query sensor history: {e}");
@@ -145,7 +149,9 @@ async fn put_settings(
 ) -> HttpResponse {
     let data = body.into_inner().to_string();
     match state.storage.save_settings(&data).await {
-        Ok(()) => HttpResponse::Ok().json(serde_json::from_str::<serde_json::Value>(&data).unwrap()),
+        Ok(()) => {
+            HttpResponse::Ok().json(serde_json::from_str::<serde_json::Value>(&data).unwrap())
+        }
         Err(e) => {
             tracing::error!("Failed to save settings: {e}");
             HttpResponse::InternalServerError().finish()
@@ -208,10 +214,7 @@ pub fn create_app(
                             web::post().to(hue::handlers::toggle_motion),
                         ),
                 )
-                .service(
-                    web::scope("/solis")
-                        .route("", web::get().to(solis::handlers::get_data)),
-                )
+                .service(web::scope("/solis").route("", web::get().to(solis::handlers::get_data)))
                 .service(
                     web::scope("/pv").service(
                         web::resource("/forecast")

--- a/backend/src/reserve/handlers.rs
+++ b/backend/src/reserve/handlers.rs
@@ -1,0 +1,173 @@
+use std::sync::Arc;
+
+use actix_web::{web, HttpResponse};
+use chrono::{Days, NaiveDate};
+use serde::Deserialize;
+use utoipa::IntoParams;
+
+use super::models::{FeeRow, ReservePoint, ReserveResponse};
+use crate::AppState;
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ReserveQuery {
+    /// Resolution: hour|day|week|month|year (default: month).
+    pub steps: Option<String>,
+    /// Provider key (default: the single configured provider).
+    pub provider: Option<String>,
+}
+
+const CURRENCY: &str = "EUR";
+
+#[utoipa::path(
+    get,
+    path = "/api/reserve",
+    params(ReserveQuery),
+    responses(
+        (status = 200, description = "Reserve-market payout series", body = super::models::ReserveResponse),
+        (status = 500, description = "Database error"),
+    )
+)]
+pub async fn get_reserve(
+    state: web::Data<Arc<AppState>>,
+    query: web::Query<ReserveQuery>,
+) -> HttpResponse {
+    let steps = query.steps.clone().unwrap_or_else(|| "month".into());
+    let provider = query
+        .provider
+        .clone()
+        .unwrap_or_else(|| state.settings.reserve_provider.clone());
+
+    let rows = match state.storage.query_reserve_profit(&provider, &steps).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("reserve: failed to read profit rows: {e}");
+            return HttpResponse::InternalServerError().finish();
+        }
+    };
+    // The fee is a monthly amount, so payout is only meaningful at month resolution.
+    let fee_applied = steps == "month";
+    let fees = if fee_applied {
+        state
+            .storage
+            .query_reserve_fees(&provider)
+            .await
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let display_name = state
+        .storage
+        .query_reserve_display_name(&provider)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| provider.clone());
+
+    let mut points = Vec::with_capacity(rows.len());
+    let (mut total_gross, mut total_payout, mut total_spot) = (0.0, 0.0, 0.0);
+
+    for r in &rows {
+        let gross = r.fcr_up + r.fcr_down;
+        let (fee, payout) = if fee_applied {
+            match fee_for(&fees, &r.bucket_start) {
+                Some(rule) => rule.apply(r.capacity_kw, gross),
+                None => {
+                    tracing::warn!(
+                        "reserve: no fee period covers {} for {provider}; payout = gross",
+                        r.bucket_start
+                    );
+                    (0.0, gross)
+                }
+            }
+        } else {
+            (0.0, gross)
+        };
+
+        total_gross += gross;
+        total_payout += payout;
+        total_spot += r.spot_saving;
+
+        points.push(ReservePoint {
+            bucket_start: r.bucket_start.clone(),
+            fcr_up: r.fcr_up,
+            fcr_down: r.fcr_down,
+            gross,
+            spot_saving: r.spot_saving,
+            fee,
+            payout,
+            is_final: r.is_final,
+        });
+    }
+
+    HttpResponse::Ok().json(ReserveResponse {
+        provider,
+        display_name,
+        currency: CURRENCY.into(),
+        steps,
+        fee_applied,
+        total_gross,
+        total_payout,
+        total_spot_saving: total_spot,
+        points,
+    })
+}
+
+/// Find the fee rule covering a bucket. Buckets are stored in UTC but aligned to
+/// the provider's local month, so a bucket can read `...-05-31T21:00:00Z` for the
+/// following month; a 2-day cushion lands classification firmly inside the
+/// intended month before the half-open `[from, to)` lookup.
+fn fee_for<'a>(fees: &'a [FeeRow], bucket_start: &str) -> Option<&'a super::models::FeeRule> {
+    let dt = chrono::DateTime::parse_from_rfc3339(bucket_start).ok()?;
+    let date: NaiveDate = dt
+        .with_timezone(&chrono::Utc)
+        .checked_add_days(Days::new(2))?
+        .date_naive();
+    fees.iter()
+        .find(|f| f.from <= date && f.to.is_none_or(|t| date < t))
+        .map(|f| &f.rule)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reserve::models::{FeeRow, FeeRule};
+
+    fn eras() -> Vec<FeeRow> {
+        vec![
+            FeeRow {
+                from: NaiveDate::from_ymd_opt(2025, 11, 1).unwrap(),
+                to: Some(NaiveDate::from_ymd_opt(2026, 6, 1).unwrap()),
+                rule: FeeRule::Flat {
+                    amount: 30.0,
+                    vat_included: true,
+                },
+            },
+            FeeRow {
+                from: NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+                to: None,
+                rule: FeeRule::PerKw {
+                    rate: 2.0,
+                    min: 19.0,
+                    vat_included: true,
+                },
+            },
+        ]
+    }
+
+    #[test]
+    fn june_bucket_aligned_to_local_month_picks_new_era() {
+        // A month's bucket is stored at the prior 21:00Z (local-time offset). The
+        // 2-day cushion must still classify it into the later (per_kw) era, not the
+        // earlier one.
+        let eras = eras();
+        let rule = fee_for(&eras, "2026-05-31T21:00:00.000Z").expect("covered");
+        assert!(matches!(rule, FeeRule::PerKw { .. }));
+    }
+
+    #[test]
+    fn may_bucket_picks_old_flat_era() {
+        let eras = eras();
+        let rule = fee_for(&eras, "2026-04-30T21:00:00.000Z").expect("covered");
+        assert!(matches!(rule, FeeRule::Flat { .. }));
+    }
+}

--- a/backend/src/reserve/mod.rs
+++ b/backend/src/reserve/mod.rs
@@ -1,0 +1,6 @@
+//! Reserve-market payout — read-only consumer of the `reserve_*` tables that an
+//! external updater writes (halo never fetches the upstream itself). halo owns the
+//! generic fee MODEL + payout math here; the fee VALUES are written by the updater.
+pub mod handlers;
+pub mod models;
+pub mod storage;

--- a/backend/src/reserve/models.rs
+++ b/backend/src/reserve/models.rs
@@ -1,0 +1,180 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// A stored profit bucket (raw DB row).
+#[derive(Debug, Clone)]
+pub struct ProfitRow {
+    pub bucket_start: String,
+    pub fcr_up: f64,
+    pub fcr_down: f64,
+    pub spot_saving: f64,
+    pub capacity_kw: f64,
+    pub is_final: bool,
+}
+
+/// One time-versioned fee period.
+#[derive(Debug, Clone)]
+pub struct FeeRow {
+    pub from: chrono::NaiveDate,
+    pub to: Option<chrono::NaiveDate>,
+    pub rule: FeeRule,
+}
+
+/// The generic fee model (mirrors the updater's `fees.toml`). `flat`/`tiered`/
+/// `per_kw` are subtractive thresholds (payout floored at 0); `percent` scales.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum FeeRule {
+    None,
+    Flat {
+        amount: f64,
+        #[serde(default)]
+        vat_included: bool,
+    },
+    Tiered {
+        brackets: Vec<Bracket>,
+        #[serde(default)]
+        vat_included: bool,
+    },
+    PerKw {
+        rate: f64,
+        #[serde(default)]
+        min: f64,
+        #[serde(default)]
+        vat_included: bool,
+    },
+    Percent {
+        rate: f64,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Bracket {
+    /// Upper bound (kW) for this bracket; `None` = top/open bracket.
+    pub up_to_kw: Option<f64>,
+    pub amount: f64,
+}
+
+impl FeeRule {
+    /// Monthly fee amount for a measured capacity and gross reserve income.
+    pub fn amount(&self, capacity_kw: f64, gross: f64) -> f64 {
+        match self {
+            FeeRule::None => 0.0,
+            FeeRule::Flat { amount, .. } => *amount,
+            FeeRule::PerKw { rate, min, .. } => (rate * capacity_kw).max(*min),
+            FeeRule::Tiered { brackets, .. } => brackets
+                .iter()
+                .find(|b| b.up_to_kw.is_none_or(|c| capacity_kw <= c))
+                .map(|b| b.amount)
+                .unwrap_or(0.0),
+            FeeRule::Percent { rate } => rate * gross,
+        }
+    }
+
+    pub fn is_percent(&self) -> bool {
+        matches!(self, FeeRule::Percent { .. })
+    }
+
+    /// `(fee, payout)` for a month. Threshold-type fees floor payout at 0 (the
+    /// provider never bills below zero); `percent` scales income instead.
+    pub fn apply(&self, capacity_kw: f64, gross: f64) -> (f64, f64) {
+        let fee = self.amount(capacity_kw, gross);
+        let payout = if self.is_percent() {
+            gross - fee
+        } else {
+            (gross - fee).max(0.0)
+        };
+        (fee, payout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn old_flat_fee_floors_to_zero() {
+        // May 2026 gross €27.82 under the old ~€30 flat era → €0 payout.
+        let rule = FeeRule::Flat {
+            amount: 30.0,
+            vat_included: true,
+        };
+        let (fee, payout) = rule.apply(9.0, 27.82);
+        assert_eq!(fee, 30.0);
+        assert_eq!(payout, 0.0);
+    }
+
+    #[test]
+    fn new_per_kw_fee_clears_threshold() {
+        // From June 2026: 2 €/kW, min €19. 9 kW → max(19, 18) = €19 → €27.82 nets €8.82.
+        let rule = FeeRule::PerKw {
+            rate: 2.0,
+            min: 19.0,
+            vat_included: true,
+        };
+        let (fee, payout) = rule.apply(9.0, 27.82);
+        assert_eq!(fee, 19.0);
+        assert!((payout - 8.82).abs() < 1e-9);
+    }
+
+    #[test]
+    fn percent_scales_income() {
+        let rule = FeeRule::Percent { rate: 0.2 };
+        let (fee, payout) = rule.apply(9.0, 100.0);
+        assert!((fee - 20.0).abs() < 1e-9);
+        assert!((payout - 80.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn tiered_picks_bracket_by_capacity() {
+        let rule = FeeRule::Tiered {
+            vat_included: true,
+            brackets: vec![
+                Bracket {
+                    up_to_kw: Some(5.0),
+                    amount: 19.0,
+                },
+                Bracket {
+                    up_to_kw: None,
+                    amount: 34.9,
+                },
+            ],
+        };
+        assert_eq!(rule.amount(4.0, 0.0), 19.0);
+        assert_eq!(rule.amount(9.0, 0.0), 34.9);
+    }
+}
+
+/// One point in the payout series returned to the frontend.
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReservePoint {
+    pub bucket_start: String,
+    pub fcr_up: f64,
+    pub fcr_down: f64,
+    /// Reserve income only (fcr_up + fcr_down) — excludes spot_saving.
+    pub gross: f64,
+    /// Provider's estimated spot-arbitrage saving; surfaced separately, never
+    /// summed into payout.
+    pub spot_saving: f64,
+    pub fee: f64,
+    pub payout: f64,
+    pub is_final: bool,
+}
+
+/// The reserve payout series + headline totals.
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReserveResponse {
+    pub provider: String,
+    pub display_name: String,
+    pub currency: String,
+    pub steps: String,
+    /// True only at monthly resolution — the fee is a monthly amount, so payout is
+    /// only meaningful per month. Other resolutions return gross with fee = 0.
+    pub fee_applied: bool,
+    pub total_gross: f64,
+    pub total_payout: f64,
+    pub total_spot_saving: f64,
+    pub points: Vec<ReservePoint>,
+}

--- a/backend/src/reserve/storage.rs
+++ b/backend/src/reserve/storage.rs
@@ -1,0 +1,111 @@
+use rusqlite::Connection;
+
+use super::models::{FeeRow, FeeRule, ProfitRow};
+
+/// Canonical `reserve_*` schema. The external updater writes these tables; halo
+/// only reads. Idempotent `CREATE TABLE IF NOT EXISTS` — no migrations, no ALTER.
+pub fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS reserve_profit (
+             provider     TEXT NOT NULL,
+             steps        TEXT NOT NULL,
+             bucket_start TEXT NOT NULL,
+             fcr_up       REAL NOT NULL DEFAULT 0,
+             fcr_down     REAL NOT NULL DEFAULT 0,
+             spot_saving  REAL NOT NULL DEFAULT 0,
+             capacity_kw  REAL NOT NULL DEFAULT 0,
+             is_final     INTEGER NOT NULL DEFAULT 0,
+             fetched_at   TEXT NOT NULL,
+             PRIMARY KEY (provider, steps, bucket_start)
+         );
+
+         CREATE TABLE IF NOT EXISTS reserve_fee (
+             provider       TEXT NOT NULL,
+             effective_from TEXT NOT NULL,
+             effective_to   TEXT,
+             fee_json       TEXT NOT NULL,
+             source         TEXT,
+             PRIMARY KEY (provider, effective_from)
+         );
+
+         CREATE TABLE IF NOT EXISTS reserve_meta (
+             provider     TEXT PRIMARY KEY,
+             activation   TEXT,
+             display_name TEXT
+         );",
+    )
+}
+
+pub fn read_profit(
+    conn: &Connection,
+    provider: &str,
+    steps: &str,
+) -> rusqlite::Result<Vec<ProfitRow>> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT bucket_start, fcr_up, fcr_down, spot_saving, capacity_kw, is_final
+         FROM reserve_profit
+         WHERE provider = ?1 AND steps = ?2
+         ORDER BY bucket_start ASC",
+    )?;
+    let rows = stmt
+        .query_map(rusqlite::params![provider, steps], |row| {
+            Ok(ProfitRow {
+                bucket_start: row.get(0)?,
+                fcr_up: row.get(1)?,
+                fcr_down: row.get(2)?,
+                spot_saving: row.get(3)?,
+                capacity_kw: row.get(4)?,
+                is_final: row.get::<_, i64>(5)? != 0,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>();
+    rows
+}
+
+pub fn read_fees(conn: &Connection, provider: &str) -> rusqlite::Result<Vec<FeeRow>> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT effective_from, effective_to, fee_json
+         FROM reserve_fee
+         WHERE provider = ?1
+         ORDER BY effective_from ASC",
+    )?;
+    let rows = stmt
+        .query_map(rusqlite::params![provider], |row| {
+            let from: String = row.get(0)?;
+            let to: Option<String> = row.get(1)?;
+            let fee_json: String = row.get(2)?;
+            Ok((from, to, fee_json))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    // Parse outside the SQLite closure (serde/chrono errors aren't rusqlite errors);
+    // skip + warn on any malformed row rather than failing the whole request.
+    let mut out = Vec::new();
+    for (from, to, fee_json) in rows {
+        let parsed_from = chrono::NaiveDate::parse_from_str(&from, "%Y-%m-%d");
+        let rule = serde_json::from_str::<FeeRule>(&fee_json);
+        match (parsed_from, rule) {
+            (Ok(from), Ok(rule)) => out.push(FeeRow {
+                from,
+                to: to.and_then(|s| chrono::NaiveDate::parse_from_str(&s, "%Y-%m-%d").ok()),
+                rule,
+            }),
+            _ => {
+                tracing::warn!("reserve_fee row for {provider} from={from} is malformed; skipping")
+            }
+        }
+    }
+    Ok(out)
+}
+
+pub fn read_display_name(conn: &Connection, provider: &str) -> rusqlite::Result<Option<String>> {
+    let mut stmt =
+        conn.prepare_cached("SELECT display_name FROM reserve_meta WHERE provider = ?1")?;
+    let v = stmt
+        .query_row(rusqlite::params![provider], |r| {
+            r.get::<_, Option<String>>(0)
+        })
+        .ok()
+        .flatten();
+    Ok(v)
+}

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -15,6 +15,9 @@ pub struct Settings {
     pub solis_key_secret: String,
     pub solis_station_id: String,
     pub solis_base_url: String,
+    /// Default provider key for the reserve tables. Generic default; a local
+    /// deploy can set RESERVE_PROVIDER to a real name to match its updater.
+    pub reserve_provider: String,
 }
 
 impl Settings {
@@ -34,6 +37,7 @@ impl Settings {
             solis_key_secret: String::new(),
             solis_station_id: String::new(),
             solis_base_url: "https://www.soliscloud.com:13333".into(),
+            reserve_provider: "reserve".into(),
         }
     }
 
@@ -66,6 +70,7 @@ impl Settings {
             solis_station_id: env::var("SOLIS_STATION_ID").unwrap_or_default(),
             solis_base_url: env::var("SOLIS_BASE_URL")
                 .unwrap_or_else(|_| "https://www.soliscloud.com:13333".into()),
+            reserve_provider: env::var("RESERVE_PROVIDER").unwrap_or_else(|_| "reserve".into()),
         }
     }
 }

--- a/backend/src/solis/handlers.rs
+++ b/backend/src/solis/handlers.rs
@@ -37,8 +37,7 @@ pub async fn get_data(state: web::Data<Arc<AppState>>) -> HttpResponse {
                 tracing::warn!("Returning stale SolisCloud data");
                 return HttpResponse::Ok().json(stale);
             }
-            HttpResponse::BadGateway()
-                .json(serde_json::json!({"error": e.to_string()}))
+            HttpResponse::BadGateway().json(serde_json::json!({"error": e.to_string()}))
         }
     }
 }
@@ -65,7 +64,11 @@ pub async fn get_history(
     query: web::Query<SolisHistoryQuery>,
 ) -> HttpResponse {
     let hours = query.hours.unwrap_or(24).min(720);
-    match state.storage.query_solis_readings(hours, query.max_points).await {
+    match state
+        .storage
+        .query_solis_readings(hours, query.max_points)
+        .await
+    {
         Ok(readings) => HttpResponse::Ok().json(readings),
         Err(e) => {
             tracing::error!("Failed to query Solis history: {e}");

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -60,10 +60,36 @@ impl Storage {
 
         pv_storage::init_schema(&conn)?;
         solis_storage::init_schema(&conn)?;
+        crate::reserve::storage::init_schema(&conn)?;
 
         Ok(Self {
             conn: Mutex::new(conn),
         })
+    }
+
+    pub async fn query_reserve_profit(
+        &self,
+        provider: &str,
+        steps: &str,
+    ) -> rusqlite::Result<Vec<crate::reserve::models::ProfitRow>> {
+        let conn = self.conn.lock().await;
+        crate::reserve::storage::read_profit(&conn, provider, steps)
+    }
+
+    pub async fn query_reserve_fees(
+        &self,
+        provider: &str,
+    ) -> rusqlite::Result<Vec<crate::reserve::models::FeeRow>> {
+        let conn = self.conn.lock().await;
+        crate::reserve::storage::read_fees(&conn, provider)
+    }
+
+    pub async fn query_reserve_display_name(
+        &self,
+        provider: &str,
+    ) -> rusqlite::Result<Option<String>> {
+        let conn = self.conn.lock().await;
+        crate::reserve::storage::read_display_name(&conn, provider)
     }
 
     pub async fn upsert_pv_forecast(&self, forecast: &PvForecast) -> rusqlite::Result<usize> {

--- a/backend/src/weather/fmi/client.rs
+++ b/backend/src/weather/fmi/client.rs
@@ -36,10 +36,7 @@ pub async fn fetch_observation(
     let params = parse_timeseries_xml(&xml)?;
 
     // Find the latest timestamp that has at least temperature
-    let all_times: Vec<&DateTime<Utc>> = params
-        .values()
-        .flat_map(|ts| ts.keys())
-        .collect();
+    let all_times: Vec<&DateTime<Utc>> = params.values().flat_map(|ts| ts.keys()).collect();
 
     let latest = match all_times.into_iter().max() {
         Some(t) => *t,
@@ -103,8 +100,7 @@ pub async fn fetch_ecmwf(
     lon: &str,
 ) -> Result<Vec<FmiForecastPoint>, FmiError> {
     // ECMWF defaults to a short range — explicitly request 10 days ahead
-    let end = (chrono::Utc::now() + chrono::Duration::days(10))
-        .format("%Y-%m-%dT00:00:00Z");
+    let end = (chrono::Utc::now() + chrono::Duration::days(10)).format("%Y-%m-%dT00:00:00Z");
     let url = format!(
         "{base_url}?service=WFS&version=2.0.0&request=getFeature\
          &storedquery_id=ecmwf::forecast::surface::point::timevaluepair\
@@ -200,17 +196,14 @@ fn parse_timeseries_xml(xml: &str) -> Result<ParameterMap, FmiError> {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
                 let ln = e.local_name();
-                let local_name = std::str::from_utf8(ln.as_ref())
-                    .unwrap_or_default();
+                let local_name = std::str::from_utf8(ln.as_ref()).unwrap_or_default();
                 match local_name {
                     "MeasurementTimeseries" => {
                         for attr in e.attributes().flatten() {
                             let kn = attr.key.local_name();
-                            let key = std::str::from_utf8(kn.as_ref())
-                                .unwrap_or_default();
+                            let key = std::str::from_utf8(kn.as_ref()).unwrap_or_default();
                             if key == "id" {
-                                let id = std::str::from_utf8(&attr.value)
-                                    .unwrap_or_default();
+                                let id = std::str::from_utf8(&attr.value).unwrap_or_default();
                                 if let Some(name) = extract_param_name(id) {
                                     current_param = Some(name);
                                 }
@@ -224,8 +217,7 @@ fn parse_timeseries_xml(xml: &str) -> Result<ParameterMap, FmiError> {
             }
             Ok(Event::End(ref e)) => {
                 let ln = e.local_name();
-                let local_name = std::str::from_utf8(ln.as_ref())
-                    .unwrap_or_default();
+                let local_name = std::str::from_utf8(ln.as_ref()).unwrap_or_default();
                 match local_name {
                     "MeasurementTimeseries" => {
                         current_param = None;
@@ -244,18 +236,12 @@ fn parse_timeseries_xml(xml: &str) -> Result<ParameterMap, FmiError> {
                     if in_time {
                         current_time = Some(text);
                     } else if in_value {
-                        if let (Some(param), Some(time_str)) =
-                            (&current_param, &current_time)
-                        {
+                        if let (Some(param), Some(time_str)) = (&current_param, &current_time) {
                             if text != "NaN" {
-                                if let (Ok(time), Ok(val)) = (
-                                    time_str.parse::<DateTime<Utc>>(),
-                                    text.parse::<f64>(),
-                                ) {
-                                    params
-                                        .entry(param.clone())
-                                        .or_default()
-                                        .insert(time, val);
+                                if let (Ok(time), Ok(val)) =
+                                    (time_str.parse::<DateTime<Utc>>(), text.parse::<f64>())
+                                {
+                                    params.entry(param.clone()).or_default().insert(time, val);
                                 }
                             }
                         }
@@ -288,10 +274,7 @@ fn get_val(params: &ParameterMap, name: &str, time: &DateTime<Utc>) -> Option<f6
 }
 
 fn collect_times(params: &ParameterMap) -> Vec<DateTime<Utc>> {
-    let mut times: Vec<DateTime<Utc>> = params
-        .values()
-        .flat_map(|ts| ts.keys().copied())
-        .collect();
+    let mut times: Vec<DateTime<Utc>> = params.values().flat_map(|ts| ts.keys().copied()).collect();
     times.sort();
     times.dedup();
     times
@@ -309,11 +292,7 @@ fn compute_wind_from_uv(u: Option<f64>, v: Option<f64>) -> (Option<f64>, Option<
 }
 
 /// Infer weather symbol from available ECMWF data when WeatherSymbol3 is not available.
-fn infer_weather_symbol(
-    temp: Option<f64>,
-    precip: Option<f64>,
-    humidity: Option<f64>,
-) -> i32 {
+fn infer_weather_symbol(temp: Option<f64>, precip: Option<f64>, humidity: Option<f64>) -> i32 {
     let temp = temp.unwrap_or(0.0);
     let precip = precip.unwrap_or(0.0);
     let humidity = humidity.unwrap_or(50.0);
@@ -388,7 +367,8 @@ mod tests {
         assert_eq!(infer_weather_symbol(Some(10.0), Some(1.0), Some(80.0)), 32); // rain
         assert_eq!(infer_weather_symbol(Some(-5.0), Some(1.0), Some(80.0)), 52); // snow
         assert_eq!(infer_weather_symbol(Some(1.0), Some(1.0), Some(80.0)), 72); // sleet
-        assert_eq!(infer_weather_symbol(Some(10.0), Some(5.0), Some(80.0)), 33); // heavy rain
+        assert_eq!(infer_weather_symbol(Some(10.0), Some(5.0), Some(80.0)), 33);
+        // heavy rain
     }
 
     #[test]

--- a/backend/src/weather/fmi/converter.rs
+++ b/backend/src/weather/fmi/converter.rs
@@ -91,11 +91,7 @@ fn build_hourly(forecasts: &[FmiForecastPoint]) -> Vec<HourlyForecast> {
         .collect()
 }
 
-fn build_daily(
-    forecasts: &[FmiForecastPoint],
-    lat: f64,
-    lon: f64,
-) -> Vec<DailyForecast> {
+fn build_daily(forecasts: &[FmiForecastPoint], lat: f64, lon: f64) -> Vec<DailyForecast> {
     let helsinki = FixedOffset::east_opt(3 * 3600).unwrap();
 
     // Group forecasts by local date
@@ -110,17 +106,11 @@ fn build_daily(
         .into_iter()
         .filter(|(_, points)| points.len() >= 2) // need at least 2 data points for a daily summary
         .map(|(date, points)| {
-            let temps: Vec<f64> = points
-                .iter()
-                .filter_map(|p| p.temperature)
-                .collect();
+            let temps: Vec<f64> = points.iter().filter_map(|p| p.temperature).collect();
             let temp_max = temps.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
             let temp_min = temps.iter().cloned().fold(f64::INFINITY, f64::min);
 
-            let total_precip: f64 = points
-                .iter()
-                .filter_map(|p| p.precipitation_1h)
-                .sum();
+            let total_precip: f64 = points.iter().filter_map(|p| p.precipitation_1h).sum();
 
             let precip_type = determine_precip_type(&points);
 
@@ -185,17 +175,17 @@ fn most_severe_symbol(points: &[&FmiForecastPoint]) -> i32 {
 
 fn symbol_severity(symbol: i32) -> i32 {
     match symbol {
-        1 => 0,                        // clear
-        2 => 1,                        // partly cloudy
-        3 => 2,                        // cloudy
-        91 | 92 => 3,                  // fog
-        21 | 31 | 81 => 4,            // light rain/showers
-        41 | 51 => 5,                  // light snow
-        71 | 73 => 6,                  // sleet
-        22 | 32 | 82 => 7,            // rain/showers
-        42 | 52 | 72 => 8,            // snow/sleet
-        23 | 33 | 43 | 53 | 83 => 9,  // heavy precip
-        61..=64 => 10,                 // thunder
+        1 => 0,                      // clear
+        2 => 1,                      // partly cloudy
+        3 => 2,                      // cloudy
+        91 | 92 => 3,                // fog
+        21 | 31 | 81 => 4,           // light rain/showers
+        41 | 51 => 5,                // light snow
+        71 | 73 => 6,                // sleet
+        22 | 32 | 82 => 7,           // rain/showers
+        42 | 52 | 72 => 8,           // snow/sleet
+        23 | 33 | 43 | 53 | 83 => 9, // heavy precip
+        61..=64 => 10,               // thunder
         _ => 0,
     }
 }
@@ -207,11 +197,29 @@ fn guess_symbol_from_observation(obs: &FmiObservation) -> i32 {
     let temp = obs.temperature.unwrap_or(0.0);
 
     if precip > 2.0 {
-        if temp > 2.0 { 33 } else if temp <= 0.0 { 53 } else { 73 }
+        if temp > 2.0 {
+            33
+        } else if temp <= 0.0 {
+            53
+        } else {
+            73
+        }
     } else if precip > 0.0 {
-        if temp > 2.0 { 32 } else if temp <= 0.0 { 52 } else { 72 }
+        if temp > 2.0 {
+            32
+        } else if temp <= 0.0 {
+            52
+        } else {
+            72
+        }
     } else if let Some(okta) = cloud {
-        if okta <= 1.0 { 1 } else if okta <= 4.0 { 2 } else { 3 }
+        if okta <= 1.0 {
+            1
+        } else if okta <= 4.0 {
+            2
+        } else {
+            3
+        }
     } else {
         2 // default to partly cloudy when unknown
     }
@@ -227,8 +235,8 @@ fn wind_chill(temp: f64, wind_speed: f64) -> f64 {
     if wind_kmh < 4.8 {
         return temp;
     }
-    let wc = 13.12 + 0.6215 * temp - 11.37 * wind_kmh.powf(0.16)
-        + 0.3965 * temp * wind_kmh.powf(0.16);
+    let wc =
+        13.12 + 0.6215 * temp - 11.37 * wind_kmh.powf(0.16) + 0.3965 * temp * wind_kmh.powf(0.16);
     // Don't return a value higher than actual temperature
     wc.min(temp)
 }

--- a/backend/src/weather/handlers.rs
+++ b/backend/src/weather/handlers.rs
@@ -51,14 +51,8 @@ pub async fn fmi(
     .await
     {
         Ok(fmi_data) => {
-            let lat: f64 = query
-                .lat
-                .parse()
-                .expect("lat must be a valid number");
-            let lon: f64 = query
-                .lon
-                .parse()
-                .expect("lon must be a valid number");
+            let lat: f64 = query.lat.parse().expect("lat must be a valid number");
+            let lon: f64 = query.lon.parse().expect("lon must be a valid number");
             let converter = FmiConverter;
             let response = converter.convert(&fmi_data, lat, lon);
             state.weather_cache.set(key, response.clone()).await;

--- a/backend/src/weather/sun.rs
+++ b/backend/src/weather/sun.rs
@@ -26,11 +26,7 @@ pub fn sunrise_sunset(lat: f64, lon: f64, date: NaiveDate) -> (String, String) {
     (format_ms(sunrise_ms), format_ms(sunset_ms))
 }
 
-pub fn sunrise_sunset_for_utc_date(
-    lat: f64,
-    lon: f64,
-    dt: &DateTime<Utc>,
-) -> (String, String) {
+pub fn sunrise_sunset_for_utc_date(lat: f64, lon: f64, dt: &DateTime<Utc>) -> (String, String) {
     let helsinki = FixedOffset::east_opt(HELSINKI_OFFSET).unwrap();
     let local = dt.with_timezone(&helsinki);
     sunrise_sunset(lat, lon, local.date_naive())

--- a/backend/src/weather/tomorrow/client.rs
+++ b/backend/src/weather/tomorrow/client.rs
@@ -29,7 +29,11 @@ const FIELDS: &[&str] = &[
 
 const TIMESTEPS: &str = "current,1d,1h";
 
-pub async fn fetch(state: &AppState, lat: &str, lon: &str) -> Result<serde_json::Value, TomorrowError> {
+pub async fn fetch(
+    state: &AppState,
+    lat: &str,
+    lon: &str,
+) -> Result<serde_json::Value, TomorrowError> {
     let settings = &state.settings;
 
     let url = format!(

--- a/backend/tests/smoke.rs
+++ b/backend/tests/smoke.rs
@@ -58,6 +58,7 @@ fn test_settings_with_mock(mock_url: &str) -> Settings {
         solis_key_id: "".into(),
         solis_key_secret: "".into(),
         solis_station_id: "".into(),
+        reserve_provider: "reserve".into(),
     }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { api } from "./api";
 import CurrentTime from "./components/CurrentTime";
 import EnergyDailyHistory from "./components/Energy/DailyHistory";
 import EnergyFlow from "./components/Energy/Flow";
+import EnergyReserve from "./components/Energy/Reserve";
 import EnergySummary from "./components/Energy/Summary";
 import FmiWeatherBox from "./components/FmiWeatherBox";
 import History from "./components/History";
@@ -330,6 +331,7 @@ const App = () => {
                 <EnergyFlow />
                 <EnergySummary />
                 <EnergyDailyHistory />
+                <EnergyReserve />
               </div>
             )}
 

--- a/frontend/src/components/Energy/Reserve.tsx
+++ b/frontend/src/components/Energy/Reserve.tsx
@@ -1,0 +1,269 @@
+import { useTheme } from "@emotion/react";
+import {
+  BarController,
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  ChartData,
+  ChartOptions,
+  Legend,
+  LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
+  Tooltip,
+} from "chart.js";
+import { format } from "date-fns";
+import { fi } from "date-fns/locale/fi";
+import { memo, useEffect, useState } from "react";
+import { Chart } from "react-chartjs-2";
+
+import { api } from "../../api";
+import { mq } from "../../mq";
+import { ReserveResponse } from "../../types/reserve";
+
+ChartJS.register(
+  BarController,
+  BarElement,
+  CategoryScale,
+  Legend,
+  LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
+  Tooltip,
+);
+
+const eur = (v: number) => `${v.toFixed(2)} €`;
+
+const RANGES = [
+  { label: "12kk", months: 12 },
+  { label: "24kk", months: 24 },
+  { label: "kaikki", months: Infinity },
+] as const;
+type Range = (typeof RANGES)[number];
+
+const Reserve: React.FC<{ className?: string }> = ({ className }) => {
+  const theme = useTheme();
+  const [data, setData] = useState<ReserveResponse>();
+  const [error, setError] = useState(false);
+  const [range, setRange] = useState<Range>(RANGES[0]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(api("/api/reserve?steps=month"), { signal: controller.signal })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((d: ReserveResponse) => {
+        setData(d);
+        setError(false);
+      })
+      .catch((err) => {
+        if (err.name !== "AbortError") setError(true);
+      });
+    return () => controller.abort();
+  }, []);
+
+  // Header totals stay lifetime (from the API); the chart shows a recent window
+  // so it stays legible on a narrow phone as months accumulate.
+  const allPoints = data?.points ?? [];
+  const points =
+    range.months === Infinity ? allPoints : allPoints.slice(-range.months);
+  const labels = points.map((p) =>
+    format(new Date(p.bucketStart), "LLL yy", { locale: fi }),
+  );
+  const tickColor = theme.colors.text.muted;
+
+  // One bar = total reserve income, split at the fee threshold: the grey base is
+  // the part the fee eats, the green top is what clears it (= payout). The two
+  // bar segments stack to gross; the threshold line gets its own stack id so the
+  // stacked y-axis renders it at its true value rather than summing.
+  const chartData: ChartData<"bar" | "line", number[], string> = {
+    labels,
+    datasets: [
+      {
+        type: "bar",
+        label: "tulot",
+        data: points.map((p) => p.gross - p.payout),
+        backgroundColor: theme.colors.rain,
+        stack: "income",
+        borderWidth: 0,
+      },
+      {
+        type: "bar",
+        label: "hyvitys",
+        data: points.map((p) => p.payout),
+        backgroundColor: theme.colors.connected,
+        stack: "income",
+        borderWidth: 0,
+      },
+      {
+        type: "line",
+        label: "maksuraja",
+        data: points.map((p) => p.fee),
+        borderColor: theme.colors.activity.on,
+        borderDash: [4, 4],
+        borderWidth: 1.5,
+        pointRadius: 0,
+        stepped: true,
+        stack: "fee",
+      },
+    ],
+  };
+
+  const options: ChartOptions<"bar" | "line"> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: { duration: 0 },
+    interaction: { mode: "index", intersect: false },
+    plugins: {
+      legend: {
+        position: "bottom",
+        labels: { color: theme.colors.text.main, boxWidth: 12, padding: 14 },
+      },
+      tooltip: {
+        callbacks: {
+          label: (ctx) => `${ctx.dataset.label}: ${eur(ctx.parsed.y ?? 0)}`,
+          footer: (items) =>
+            `reservitulo ${eur(
+              items
+                .filter((i) => i.dataset.type === "bar")
+                .reduce((s, i) => s + (i.parsed.y ?? 0), 0),
+            )}`,
+        },
+      },
+    },
+    scales: {
+      x: {
+        stacked: true,
+        grid: { display: false },
+        ticks: {
+          color: tickColor,
+          autoSkip: true,
+          maxRotation: 45,
+          minRotation: 45,
+        },
+      },
+      y: {
+        stacked: true,
+        beginAtZero: true,
+        grid: { tickBorderDash: [2, 2] },
+        ticks: { color: tickColor, callback: (v) => `${v} €` },
+      },
+    },
+  };
+
+  return (
+    <div
+      className={className}
+      css={{
+        backgroundColor: theme.colors.background.main,
+        boxShadow: theme.shadows.main,
+        borderRadius: theme.border.radius,
+        padding: "1.25em 1.5em",
+        [mq[0]]: { padding: "1em" },
+      }}
+    >
+      <div
+        css={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          marginBottom: "1em",
+          gap: 16,
+          flexWrap: "wrap",
+        }}
+      >
+        <div css={{ fontFamily: theme.fonts.heading, fontSize: 16 }}>
+          reservimarkkina
+        </div>
+        {data && (
+          <span
+            css={{
+              fontFamily: theme.fonts.heading,
+              fontSize: 20,
+              color:
+                data.totalPayout > 0
+                  ? theme.colors.connected
+                  : theme.colors.text.main,
+            }}
+          >
+            {eur(data.totalPayout)}
+          </span>
+        )}
+      </div>
+      {data && allPoints.length > RANGES[0].months && (
+        <div
+          css={{
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: 8,
+            marginBottom: "1em",
+          }}
+        >
+          {RANGES.map((r) => {
+            const active = r.months === range.months;
+            return (
+              <button
+                key={r.label}
+                onClick={() => setRange(r)}
+                css={{
+                  cursor: "pointer",
+                  padding: "5px 12px",
+                  borderRadius: theme.border.radius,
+                  border: `1px solid ${active ? theme.colors.activity.on : theme.colors.border}`,
+                  backgroundColor: active
+                    ? theme.colors.activity.onSoft
+                    : theme.colors.background.main,
+                  color: active
+                    ? theme.colors.activity.on
+                    : theme.colors.text.main,
+                  ...theme.typography.body2,
+                  transition: "all 0.15s",
+                }}
+              >
+                {r.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+      <div css={{ position: "relative", height: 280 }}>
+        {error ? (
+          <Centered color={tickColor}>Reservidataa ei saatavilla</Centered>
+        ) : !data ? (
+          <Centered color={tickColor}>Ladataan...</Centered>
+        ) : points.length === 0 ? (
+          <Centered color={tickColor}>Ei reservidataa</Centered>
+        ) : (
+          <Chart<"bar" | "line", number[], string>
+            type="bar"
+            data={chartData}
+            options={options}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const Centered: React.FC<{ color: string; children: React.ReactNode }> = ({
+  color,
+  children,
+}) => (
+  <div
+    css={{
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      height: "100%",
+      color,
+    }}
+  >
+    {children}
+  </div>
+);
+
+export default memo(Reserve);

--- a/frontend/src/types/reserve.ts
+++ b/frontend/src/types/reserve.ts
@@ -1,0 +1,24 @@
+export type ReservePoint = {
+  bucketStart: string;
+  fcrUp: number;
+  fcrDown: number;
+  /** Reserve income only (fcrUp + fcrDown), excludes spotSaving. */
+  gross: number;
+  spotSaving: number;
+  fee: number;
+  payout: number;
+  isFinal: boolean;
+};
+
+export type ReserveResponse = {
+  provider: string;
+  displayName: string;
+  currency: string;
+  steps: string;
+  /** True only at monthly resolution — payout is a monthly figure. */
+  feeApplied: boolean;
+  totalGross: number;
+  totalPayout: number;
+  totalSpotSaving: number;
+  points: ReservePoint[];
+};


### PR DESCRIPTION
## Summary

Adds a **reserve** feature surfacing FCR-N reserve-market income (fcr_up / fcr_down), provider fees, and spot-arbitrage savings, rendered in the Energy section.

Split into two commits for review:

1. **`feat(reserve)`** — the real change.
2. **`style`** — the rustfmt pass + fmt tooling, separated out so the diff above doesn't drown the feature.

### Backend
- New `reserve` module (models, storage, handlers) backed by SQLite tables for profit buckets, time-versioned fees, and provider display names.
- Generic fee model (`none`/`flat`/`tiered`/`per_kw`/`percent`) mirroring the updater's `fees.toml`; threshold fees floor payout at 0, `percent` scales income.
- `GET /api/reserve` serving a payout series + headline totals. Monthly resolution applies the monthly fee; other resolutions return gross with `fee = 0`.
- `RESERVE_PROVIDER` setting (default `"reserve"`) selects the provider key.

### Frontend
- `EnergyReserve` component + reserve types, wired into the Energy column.

### Tooling
- `cargo fmt --check` added to the pre-commit hook and CI (rustfmt component pulled in); backend reflowed to satisfy it.

## Test plan
- [ ] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` pass (backend).
- [ ] `yarn validate` passes (frontend).
- [ ] `GET /api/reserve` returns a payout series with correct fee application at monthly resolution.