### PR TITLE
Collapse develop→main + fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ARG HALO_IMAGE_TAG
 ENV VITE_HALO_IMAGE_TAG=$HALO_IMAGE_TAG
 WORKDIR /app
 COPY frontend/package.json frontend/yarn.lock frontend/.yarnrc.yml* ./
+# .yarnrc.yml pins yarnPath to a committed release; copy it in before install
+COPY frontend/.yarn/ ./.yarn/
 RUN corepack enable && yarn install --immutable --network-timeout 1000000
 COPY frontend/ .
 RUN yarn build


### PR DESCRIPTION
Consolidates the branch model to a single `main` branch and fixes the Docker image build.

## Changes
- **`ci`**: CI and automerge now trigger on `main` instead of `develop`. The Docker image already builds on push to `main`, so the dev/release split is no longer needed — `main` is now the single branch.
- **`fix(docker)`**: the frontend build stage copied only `package.json`, `yarn.lock`, and `.yarnrc.yml`, but `.yarnrc.yml` pins `yarnPath` to the committed `.yarn/releases/yarn-4.16.0.cjs` — which was never copied in, so corepack failed with `ENOENT`. Now copies `frontend/.yarn/` before `yarn install`.

## Verification
- Docker image workflow dispatched on this branch: **success** (run [27508882912](https://github.com/eetu/halo/actions/runs/27508882912)) — previously failed at 45s in the yarn step.

## Follow-up (remote, post-merge)
- Set default branch to `main`, protect `main` (required checks Backend/Frontend), delete `develop`.