### PR TITLE
ci: trigger on main instead of develop

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
   pull_request:
-    branches: [develop]
+    branches: [main]
 
 jobs:
   frontend:


### PR DESCRIPTION
## Problem

The default branch moved from `develop` to `main`, but `ci.yaml` still triggered only on `push`/`pull_request` to `develop`. So CI never ran for PRs into `main`, and since `main`'s branch protection **requires** the `Backend` and `Frontend` checks, every PR sat with those checks perpetually "expected/waiting" and could not merge.

## Fix

Point the CI triggers at `main`. Because `pull_request` evaluates its branch filter from the PR head, this PR self-triggers CI and is mergeable.

## After merging

Existing PRs (#977 follow-up #978) need to pick up the new trigger — update their branches from `main` (merge/rebase) and CI will start running on them.