### PR TITLE
Spot price touch UX + dev QR/proxy

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "typescript-eslint": "^8.60.1",
     "unplugin-auto-import": "^21.0.0",
     "vite": "^8.0.16",
+    "vite-plugin-qrcode": "^0.4.1",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.8",
     "vitest-browser-react": "^2.2.0"

--- a/frontend/src/components/Energy/SpotPrice.tsx
+++ b/frontend/src/components/Energy/SpotPrice.tsx
@@ -1,38 +1,34 @@
-import { useTheme } from "@emotion/react";
+import { Theme, useTheme } from "@emotion/react";
 import {
   BarElement,
   CategoryScale,
   Chart as ChartJS,
   ChartOptions,
-  ChartType,
   LinearScale,
-  Tooltip,
-  TooltipPositionerFunction,
 } from "chart.js";
-import { memo, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { Bar } from "react-chartjs-2";
 
 import { api } from "../../api";
 import { mq } from "../../mq";
 import { HourPrice, SpotResponse } from "../../types/spot";
 
-ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip);
-
-declare module "chart.js" {
-  interface TooltipPositionerMap {
-    aboveCursor: TooltipPositionerFunction<ChartType>;
-  }
-}
-
-// Pin the tooltip to the top of the chart at the pointer's x — on touch it then
-// rides above the fingertip (and slides along while scrubbing) instead of
-// hiding under it.
-Tooltip.positioners.aboveCursor = function (_items, evt) {
-  return { x: evt.x, y: this.chart.chartArea.top };
-};
+ChartJS.register(BarElement, CategoryScale, LinearScale);
 
 const HOUR_MS = 3_600_000;
 const SCALE_KEY = "halo.spot.showScale";
+
+// How long the card title keeps showing the scrubbed price after the finger
+// lifts (or the cursor leaves) before falling back to the default title.
+const REVERT_MS = 2500;
+
+// Touch loupe: a magnified patch of the chart's bottom strip (the bars' base +
+// the hour labels) floated above the fingertip so it never sits under the finger.
+// Bottom-anchored sampling keeps the hour labels in view; it follows the finger.
+const LOUPE_W = 104; // square so the bubble can be a clean circle
+const LOUPE_H = 104;
+const LOUPE_GAP = 16; // gap between the fingertip and the bottom of the loupe
+const LOUPE_ZOOM = 2; // uniform magnification (no anamorphic stretch)
 
 // Absolute price → hue (c/kWh incl. VAT): green at LO → red at HI → and on past
 // red into purple by MAX (the face of whoever pays the bill). Absolute, not
@@ -53,29 +49,125 @@ const priceHue = (price: number) => {
   return 360 - 75 * k; // 360 red → 285 purple
 };
 
+type DayKey = "today" | "tomorrow";
+type Selected = { day: DayKey; hour: string; price: number };
+type LoupeBox = { left: number; top: number; touchX: number };
+
+// Round for display, collapsing a tiny negative (e.g. -0.04 → "-0.0") to a plain
+// zero so near-zero prices don't read as negative.
+const fmtPrice = (n: number, digits: number) => {
+  const s = n.toFixed(digits);
+  return Number(s) === 0 ? (0).toFixed(digits) : s;
+};
+
+// Magnify the chart's bottom strip around the touch x (uniform zoom, so it reads
+// as a true loupe rather than a stretched band) into the loupe canvas, then mark
+// the focused column. Bottom-anchored so the hour labels always show; reads
+// straight from chart.js's own canvas so the selected-bar highlight comes along
+// for free.
+const drawLoupe = (
+  dst: HTMLCanvasElement,
+  src: HTMLCanvasElement,
+  touchX: number,
+  theme: Theme,
+) => {
+  const rect = src.getBoundingClientRect();
+  const { width: cssW, height: cssH } = rect;
+  if (!cssW || !cssH) return;
+  const dpr = src.width / cssW; // chart canvas is rendered at devicePixelRatio
+  const srcW = LOUPE_W / LOUPE_ZOOM;
+  const srcH = LOUPE_H / LOUPE_ZOOM;
+  const srcX = Math.max(0, Math.min(cssW - srcW, touchX - srcW / 2));
+  const srcY = cssH - srcH; // bottom strip: bars' base + the x-axis labels
+
+  dst.width = LOUPE_W * dpr;
+  dst.height = LOUPE_H * dpr;
+  const ctx = dst.getContext("2d");
+  if (!ctx) return;
+  ctx.clearRect(0, 0, dst.width, dst.height);
+  ctx.drawImage(
+    src,
+    srcX * dpr,
+    srcY * dpr,
+    srcW * dpr,
+    srcH * dpr,
+    0,
+    0,
+    dst.width,
+    dst.height,
+  );
+
+  // Crosshair on the exact column under the fingertip (kept honest near the
+  // edges, where the source patch is clamped and the finger is off-centre).
+  const markerX = ((touchX - srcX) / srcW) * dst.width;
+  ctx.strokeStyle = theme.colors.text.muted;
+  ctx.lineWidth = dpr;
+  ctx.beginPath();
+  ctx.moveTo(markerX, 0);
+  ctx.lineTo(markerX, dst.height);
+  ctx.stroke();
+};
+
 const PriceChart: React.FC<{
+  containerRef: React.RefObject<HTMLDivElement | null>;
   points: HourPrice[];
-  unit: string;
   yMin: number;
   yMax: number;
   now: number;
-}> = ({ points, unit, yMin, yMax, now }) => {
+  selectedHour: string | null;
+  onSelect: (hour: string, price: number) => void;
+  onRelease: () => void;
+  loupe: LoupeBox | null;
+}> = ({
+  containerRef,
+  points,
+  yMin,
+  yMax,
+  now,
+  selectedHour,
+  onSelect,
+  onRelease,
+  loupe,
+}) => {
   const theme = useTheme();
+  const loupeRef = useRef<HTMLCanvasElement>(null);
   const prices = points.map((p) => p.price);
 
-  // Time cues kept orthogonal to hue: past dimmed (alpha), current outlined.
+  // Redraw the loupe after React commits, so the magnified slice picks up the
+  // freshly rendered selected-bar highlight rather than the previous frame.
+  // (Touch handling and the loupe geometry live in the parent grid; this just
+  // paints the magnifier for whichever chart is currently being scrubbed.)
+  useEffect(() => {
+    const canvas = containerRef.current?.querySelector("canvas") ?? null;
+    if (loupe && canvas && loupeRef.current) {
+      drawLoupe(loupeRef.current, canvas, loupe.touchX, theme);
+    }
+  }, [containerRef, loupe, selectedHour, theme]);
+
+  // Time cues: past dimmed, current outlined (a thin border keeps its price hue
+  // visible), and the scrubbed hour painted a solid accent fill so it stands out
+  // even when the bar is near zero.
+  const selIndex = selectedHour
+    ? points.findIndex((p) => p.hour.slice(11, 13) === selectedHour)
+    : -1;
   const bg: string[] = [];
   const borderColor: string[] = [];
   const borderWidth: number[] = [];
-  points.forEach((p) => {
+  points.forEach((p, i) => {
     const start = new Date(p.hour).getTime();
     const past = start + HOUR_MS <= now;
     const current = !past && start <= now;
+    const selected = i === selIndex;
     bg.push(
-      past ? theme.colors.text.light : `hsl(${priceHue(p.price)}, 65%, 50%)`,
+      selected
+        ? theme.colors.activity.on
+        : past
+          ? theme.colors.text.light
+          : `hsl(${priceHue(p.price)}, 65%, 50%)`,
     );
-    borderColor.push(current ? theme.colors.text.main : "transparent");
-    borderWidth.push(current ? 2 : 0);
+    const outlineNow = current && !selected;
+    borderColor.push(outlineNow ? theme.colors.text.main : "transparent");
+    borderWidth.push(outlineNow ? 2 : 0);
   });
 
   const data = {
@@ -87,6 +179,8 @@ const PriceChart: React.FC<{
         borderColor,
         borderWidth,
         borderRadius: 2,
+        // Give near-zero hours a visible, aimable block instead of a hairline.
+        minBarLength: 3,
       },
     ],
   };
@@ -98,18 +192,23 @@ const PriceChart: React.FC<{
     // Select by column (x), not by hitting the bar itself — short bars are easy
     // to tap, and dragging scrubs hour-to-hour.
     interaction: { mode: "index", intersect: false },
-    plugins: {
-      legend: { display: false },
-      tooltip: {
-        position: "aboveCursor",
-        caretSize: 0,
-        displayColors: false,
-        callbacks: {
-          title: (items) => `klo ${items[0].label}`,
-          label: (ctx) => `${(ctx.parsed.y as number).toFixed(2)} ${unit}`,
-        },
-      },
+    // Mouse only: touch is driven by the grid-level handler, so leave it out here
+    // to avoid double-handling (and the dead zone under the x-axis labels).
+    events: ["mousemove", "mouseout"],
+    // Surface the hovered hour to the card title instead of a popup the cursor
+    // would cover.
+    onHover: (_evt, elements) => {
+      if (elements.length) {
+        const p = points[elements[0].index];
+        if (p) onSelect(p.hour.slice(11, 13), p.price);
+      } else {
+        // Cursor left the chart — start the revert countdown.
+        onRelease();
+      }
     },
+    // Tooltip is registered globally by the other charts, so disable it here
+    // explicitly — the scrubbed price shows in the card title instead.
+    plugins: { legend: { display: false }, tooltip: { enabled: false } },
     scales: {
       x: {
         grid: { display: false },
@@ -125,16 +224,26 @@ const PriceChart: React.FC<{
   };
 
   return (
-    <div
-      css={{
-        position: "relative",
-        height: 120,
-        touchAction: "pan-y", // let the page scroll vertically; chart scrubs horizontally
-        userSelect: "none",
-        WebkitTapHighlightColor: "transparent", // no grey flash on tap (iOS Safari)
-      }}
-    >
+    <div ref={containerRef} css={{ position: "relative", height: 120 }}>
       <Bar data={data} options={options} />
+      {loupe && (
+        <canvas
+          ref={loupeRef}
+          css={{
+            position: "absolute",
+            left: loupe.left,
+            top: loupe.top,
+            width: LOUPE_W,
+            height: LOUPE_H,
+            pointerEvents: "none",
+            borderRadius: "50%",
+            border: `1px solid ${theme.colors.border}`,
+            boxShadow: theme.shadows.main,
+            background: theme.colors.background.main,
+            zIndex: 5,
+          }}
+        />
+      )}
     </div>
   );
 };
@@ -171,7 +280,8 @@ const ScaleLegend: React.FC<{ unit: string }> = ({ unit }) => {
 
 // Day label + price scale: that day's min–max, and for the day containing the
 // current hour a "lowest – now – highest" readout so the live price has context.
-// Costs no chart area, so the y-axis can stay hidden.
+// Costs no chart area, so the y-axis can stay hidden. (The scrubbed-hour price
+// shows in the card title, where the touch loupe can't cover it.)
 const DayHeader: React.FC<{
   label: string;
   points: HourPrice[];
@@ -199,20 +309,87 @@ const DayHeader: React.FC<{
       <span>{label}</span>
       {ps.length > 0 && (
         <span>
-          {Math.min(...ps).toFixed(1)}
+          {fmtPrice(Math.min(...ps), 1)}
           {current !== undefined ? (
             <>
               {" – "}
               <span css={{ color: theme.colors.text.main, fontWeight: 600 }}>
-                {current.toFixed(1)}
+                {fmtPrice(current, 1)}
               </span>
               {" – "}
             </>
           ) : (
             "–"
           )}
-          {Math.max(...ps).toFixed(1)} {unit}
+          {fmtPrice(Math.max(...ps), 1)} {unit}
         </span>
+      )}
+    </div>
+  );
+};
+
+// One day's header + chart. Selection is owned by the card so a single title can
+// report whichever day is being scrubbed; this just forwards its hover events up
+// tagged with the day, and highlights its own bar when that day is selected.
+const DayPanel: React.FC<{
+  label: string;
+  day: DayKey;
+  points: HourPrice[];
+  unit: string;
+  yMin: number;
+  yMax: number;
+  now: number;
+  selected: Selected | null;
+  onSelect: (day: DayKey, hour: string, price: number) => void;
+  onRelease: () => void;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  loupe: LoupeBox | null;
+  emptyMessage?: string;
+}> = ({
+  label,
+  day,
+  points,
+  unit,
+  yMin,
+  yMax,
+  now,
+  selected,
+  onSelect,
+  onRelease,
+  containerRef,
+  loupe,
+  emptyMessage,
+}) => {
+  const theme = useTheme();
+  const sub = { ...theme.typography.caption, color: theme.colors.text.muted };
+
+  return (
+    <div css={{ minWidth: 0 }}>
+      <DayHeader label={label} points={points} unit={unit} now={now} />
+      {points.length ? (
+        <PriceChart
+          containerRef={containerRef}
+          points={points}
+          yMin={yMin}
+          yMax={yMax}
+          now={now}
+          selectedHour={selected?.day === day ? selected.hour : null}
+          onSelect={(hour, price) => onSelect(day, hour, price)}
+          onRelease={onRelease}
+          loupe={loupe}
+        />
+      ) : (
+        <div
+          css={{
+            ...sub,
+            height: 120,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          {emptyMessage}
+        </div>
       )}
     </div>
   );
@@ -223,6 +400,93 @@ const SpotPrice: React.FC<{ className?: string }> = ({ className }) => {
   const [data, setData] = useState<SpotResponse>();
   const [error, setError] = useState(false);
   const [now, setNow] = useState(() => Date.now());
+  // Scrubbed-hour selection, shared across both day charts so the card title can
+  // report whichever one is being touched. Falls back to the default title after
+  // REVERT_MS of no interaction.
+  const [selected, setSelected] = useState<Selected | null>(null);
+  const timerRef = useRef<number>(undefined);
+  useEffect(() => () => window.clearTimeout(timerRef.current), []);
+  // While the finger/cursor is on a bar: show it and cancel any pending revert
+  // (no timer runs during interaction, so a press-and-hold won't blank mid-touch).
+  const select = useCallback((day: DayKey, hour: string, price: number) => {
+    window.clearTimeout(timerRef.current);
+    // Same object identity for an unchanged selection so a steady hover doesn't
+    // churn the charts on every mousemove.
+    setSelected((prev) =>
+      prev && prev.day === day && prev.hour === hour
+        ? prev
+        : { day, hour, price },
+    );
+  }, []);
+  // On release (finger lifts / cursor leaves): one revert timer, replacing any
+  // previous one — never several in parallel.
+  const scheduleRevert = useCallback(() => {
+    window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => setSelected(null), REVERT_MS);
+  }, []);
+
+  // Touch is handled here at the grid level, not per-chart, for two reasons:
+  // a touch is captured by the element it starts on, so this lets a drag glide
+  // from one day's chart onto the other's; and selection is purely by x (any y),
+  // so near-zero bars tucked under the x-axis labels stay reachable.
+  const todayRef = useRef<HTMLDivElement | null>(null);
+  const tomorrowRef = useRef<HTMLDivElement | null>(null);
+  const [loupe, setLoupe] = useState<({ day: DayKey } & LoupeBox) | null>(null);
+
+  const handleGridTouch = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (!data) return;
+    const t = e.touches[0];
+    if (!t) return;
+    // Pick the chart the finger is nearest (works for both the side-by-side and
+    // the stacked single-column layouts).
+    let best: {
+      day: DayKey;
+      canvas: HTMLCanvasElement;
+      rect: DOMRect;
+      points: HourPrice[];
+      dist: number;
+    } | null = null;
+    for (const day of ["today", "tomorrow"] as DayKey[]) {
+      const points = day === "today" ? data.today : data.tomorrow;
+      if (!points.length) continue;
+      const canvas =
+        (day === "today" ? todayRef : tomorrowRef).current?.querySelector(
+          "canvas",
+        ) ?? null;
+      if (!canvas) continue;
+      const rect = canvas.getBoundingClientRect();
+      const dx = Math.max(rect.left - t.clientX, 0, t.clientX - rect.right);
+      const dy = Math.max(rect.top - t.clientY, 0, t.clientY - rect.bottom);
+      const dist = Math.hypot(dx, dy);
+      if (!best || dist < best.dist) best = { day, canvas, rect, points, dist };
+    }
+    if (!best || best.dist > 60) return; // touch isn't on either chart
+
+    const chart = ChartJS.getChart(best.canvas);
+    if (!chart) return;
+    const xCss = t.clientX - best.rect.left;
+    const idx = Math.max(
+      0,
+      Math.min(
+        best.points.length - 1,
+        Math.round(chart.scales.x.getValueForPixel(xCss) ?? 0),
+      ),
+    );
+    const p = best.points[idx];
+    select(best.day, p.hour.slice(11, 13), p.price);
+
+    const touchX = Math.max(0, Math.min(best.rect.width, xCss));
+    const left = Math.max(
+      0,
+      Math.min(best.rect.width - LOUPE_W, touchX - LOUPE_W / 2),
+    );
+    const top = t.clientY - best.rect.top - LOUPE_H - LOUPE_GAP;
+    setLoupe({ day: best.day, left, top, touchX });
+  };
+  const endGridTouch = () => {
+    setLoupe(null);
+    scheduleRevert();
+  };
   // The colour-scale gradient is hidden by default to save space; tapping the
   // header reveals it (no button/placeholder), remembered across reloads.
   const [showScale, setShowScale] = useState(
@@ -304,12 +568,35 @@ const SpotPrice: React.FC<{ className?: string }> = ({ className }) => {
           userSelect: "none",
         }}
       >
-        <div css={{ fontFamily: theme.fonts.heading, fontSize: 16 }}>
-          pörssisähkö
+        <div
+          css={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 10,
+            minWidth: 0,
+          }}
+        >
+          <span css={{ fontFamily: theme.fonts.heading, fontSize: 16 }}>
+            pörssisähkö
+          </span>
+          {data && selected && (
+            <span
+              css={{
+                ...sub,
+                color: theme.colors.activity.on,
+                fontWeight: 600,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {fmtPrice(selected.price, 2)} {data.unit}
+            </span>
+          )}
         </div>
         {data && (
-          <div css={sub}>
-            ka. {data.todayAverage.toFixed(2)} {data.unit}
+          <div css={{ ...sub, whiteSpace: "nowrap" }}>
+            ka. {fmtPrice(data.todayAverage, 2)} {data.unit}
           </div>
         )}
       </div>
@@ -326,60 +613,52 @@ const SpotPrice: React.FC<{ className?: string }> = ({ className }) => {
         <>
           {showScale && <ScaleLegend unit={data.unit} />}
           <div
+            onTouchStart={handleGridTouch}
+            onTouchMove={handleGridTouch}
+            onTouchEnd={endGridTouch}
+            onTouchCancel={endGridTouch}
             css={{
               display: "grid",
               gridTemplateColumns: "1fr 1fr",
               gap: 20,
               [mq[0]]: { gridTemplateColumns: "1fr", gap: 12 },
+              touchAction: "pan-y", // page scrolls vertically; charts scrub horizontally
+              userSelect: "none",
+              WebkitTapHighlightColor: "transparent", // no grey flash on tap (iOS Safari)
             }}
           >
             {/* minWidth:0 lets the grid columns shrink below the canvas's
                 intrinsic width, so the charts scale on narrow phones instead
                 of overflowing. */}
-            <div css={{ minWidth: 0 }}>
-              <DayHeader
-                label="tänään"
-                points={data.today}
-                unit={data.unit}
-                now={now}
-              />
-              <PriceChart
-                points={data.today}
-                unit={data.unit}
-                yMin={yMin}
-                yMax={yMax}
-                now={now}
-              />
-            </div>
-            <div css={{ minWidth: 0 }}>
-              <DayHeader
-                label="huomenna"
-                points={data.tomorrow}
-                unit={data.unit}
-                now={now}
-              />
-              {data.tomorrow.length ? (
-                <PriceChart
-                  points={data.tomorrow}
-                  unit={data.unit}
-                  yMin={yMin}
-                  yMax={yMax}
-                  now={now}
-                />
-              ) : (
-                <div
-                  css={{
-                    ...sub,
-                    height: 120,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  Huomisen hinnat klo 14 jälkeen
-                </div>
-              )}
-            </div>
+            <DayPanel
+              label="tänään"
+              day="today"
+              points={data.today}
+              unit={data.unit}
+              yMin={yMin}
+              yMax={yMax}
+              now={now}
+              selected={selected}
+              onSelect={select}
+              onRelease={scheduleRevert}
+              containerRef={todayRef}
+              loupe={loupe?.day === "today" ? loupe : null}
+            />
+            <DayPanel
+              label="huomenna"
+              day="tomorrow"
+              points={data.tomorrow}
+              unit={data.unit}
+              yMin={yMin}
+              yMax={yMax}
+              now={now}
+              selected={selected}
+              onSelect={select}
+              onRelease={scheduleRevert}
+              containerRef={tomorrowRef}
+              loupe={loupe?.day === "tomorrow" ? loupe : null}
+              emptyMessage="Huomisen hinnat klo 14 jälkeen"
+            />
           </div>
         </>
       )}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,19 @@
 import react from "@vitejs/plugin-react";
 import AutoImport from "unplugin-auto-import/vite";
 import { defineConfig } from "vite";
+import { qrcode } from "vite-plugin-qrcode";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // Proxy API calls to the backend so the frontend can use same-origin relative
+  // URLs (VITE_API_URL=""). This keeps `yarn dev --host` working from other LAN
+  // devices — the request hits this dev server's IP and is forwarded here to the
+  // backend on localhost, instead of the device trying its own localhost:3000.
+  server: {
+    proxy: {
+      "/api": { target: "http://localhost:3000", changeOrigin: true },
+    },
+  },
   plugins: [
     react({
       jsxImportSource: "@emotion/react",
@@ -15,5 +25,7 @@ export default defineConfig({
       imports: ["vitest"],
       dts: true,
     }),
+    // Print a scannable QR code for the LAN URL with `yarn dev --host`.
+    qrcode(),
   ],
 });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4027,6 +4027,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uqr@npm:^0.1.2":
+  version: 0.1.3
+  resolution: "uqr@npm:0.1.3"
+  checksum: 10/cde1dd270e3d39fc1870375d33a88c1ec7ac430c6e1b0b28943ad08b029dc9409076aa2213ebf2eb209cfa37abccca365d85f2cd3b1cdefbcfb68ab8c18857d3
+  languageName: node
+  linkType: hard
+
 "uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
@@ -4060,6 +4067,17 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10/474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"vite-plugin-qrcode@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "vite-plugin-qrcode@npm:0.4.1"
+  dependencies:
+    uqr: "npm:^0.1.2"
+  peerDependencies:
+    vite: ">=3"
+  checksum: 10/dd11488c2a038a4a6f7118e8eef5d825f3f3367c6ee2e0af432b2763eb2a83f104793b0376211d8cd7cb47866b8a191518477ba34f6c826e2820d700ba21e90c
   languageName: node
   linkType: hard
 
@@ -4220,6 +4238,7 @@ __metadata:
     unplugin-auto-import: "npm:^21.0.0"
     usehooks-ts: "npm:^3.1.1"
     vite: "npm:^8.0.16"
+    vite-plugin-qrcode: "npm:^0.4.1"
     vite-tsconfig-paths: "npm:^6.1.1"
     vitest: "npm:^4.1.8"
     vitest-browser-react: "npm:^2.2.0"


### PR DESCRIPTION
## Spot price chart (touch UX)

Reworks the pörssisähkö chart interaction for the wall dashboard's touch screen:

- **Title readout instead of popup** — the scrubbed hour's price shows next to "pörssisähkö" in the card title (reverting after a short idle timer), replacing the Chart.js tooltip that the fingertip covered.
- **Circular touch loupe** — magnifies the bottom strip of the chart (bars + hour labels) above the fingertip, so you can aim at the hour your finger hides.
- **Grid-level touch + x-based selection** — a drag can glide between the today/tomorrow charts (a per-chart touch was captured by the chart it started on), and near-zero bars tucked under the x-axis labels stay reachable.
- **Clearer selection** — scrubbed bar gets a solid accent fill (not a border); near-zero bars get a minimum height so they're visible and aimable.
- **`-0.0` → `0.0`** for tiny negative prices.

Mouse hover still works (Chart.js handles mouse; touch is handled at the grid level).

## Dev tooling

- `vite-plugin-qrcode` so `yarn dev --host` prints a scannable QR for the LAN URL.
- `/api` dev proxy so the frontend uses same-origin relative URLs (`VITE_API_URL=""`), keeping the dashboard reachable from other LAN devices instead of their own localhost.

> Note: `frontend/.env` is gitignored — set `VITE_API_URL=` locally for the proxy path.