### PR TITLE
feat(radar): rain radar tab with FMI observed + forecast overlay

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -910,6 +910,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "grib"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05562971efdd34c6eb6e71a99c91e93e9e6ca9dc9c632ffcff5d30781dbe319"
+dependencies = [
+ "grib-build",
+ "grib-template-derive",
+ "grib-template-helpers",
+ "num",
+ "num_enum",
+ "toml_edit",
+]
+
+[[package]]
+name = "grib-build"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "853eb06cc4a82a72556d04e61d1534933dbbbf2686346865966a7528bed189f2"
+dependencies = [
+ "csv",
+ "serde",
+]
+
+[[package]]
+name = "grib-template-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14aeea4f64eb9b82998a74f90166e452a0a2074472164ec3a41108a3656253d9"
+dependencies = [
+ "grib-template-helpers",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "grib-template-helpers"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbca98416a815503c311d5d9f3e711b7351ad2c7f8c4d6fc0642e171dd3d9b9e"
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1002,7 @@ dependencies = [
  "chrono-tz",
  "dotenvy",
  "futures-util",
+ "grib",
  "hmac",
  "md5",
  "quick-xml",
@@ -1500,10 +1543,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1522,6 +1629,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1611,6 +1740,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2362,6 +2500,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,6 +3123,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wiremock"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -29,6 +29,7 @@ hmac = "0.13.0"
 sha1 = "0.11.0"
 md5 = "0.8.0"
 base64 = "0.22.1"
+grib = { version = "0.15.6", default-features = false }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cache;
 pub mod hue;
 pub mod pv;
+pub mod radar;
 pub mod reserve;
 pub mod settings;
 pub mod solis;
@@ -30,6 +31,8 @@ pub struct AppState {
     pub solis_cache: Cache<solis::models::SolisWidgetData>,
     pub pv_cache: Cache<pv::models::PvForecast>,
     pub spot_cache: Cache<spot::models::SpotResponse>,
+    pub radar_frames_cache: Cache<radar::models::RadarFrames>,
+    pub precip_forecast_cache: Cache<radar::models::PrecipForecast>,
     pub hue_events_tx: broadcast::Sender<hue::events::HueLiveEvent>,
     pub storage: storage::Storage,
 }
@@ -51,6 +54,8 @@ pub struct AppState {
         pv::handlers::post_forecast,
         reserve::handlers::get_reserve,
         spot::handlers::get_spot,
+        radar::handlers::frames,
+        radar::handlers::forecast,
         status,
         sensor_history,
     ),
@@ -72,6 +77,9 @@ pub struct AppState {
         reserve::models::ReservePoint,
         spot::models::SpotResponse,
         spot::models::HourPrice,
+        radar::models::RadarFrames,
+        radar::models::PrecipForecast,
+        radar::models::ForecastFrame,
         StatusResponse,
         storage::SensorReading,
     ))
@@ -230,7 +238,13 @@ pub fn create_app(
                 .service(
                     web::scope("/reserve").route("", web::get().to(reserve::handlers::get_reserve)),
                 )
-                .service(web::scope("/spot").route("", web::get().to(spot::handlers::get_spot))),
+                .service(web::scope("/spot").route("", web::get().to(spot::handlers::get_spot)))
+                .service(
+                    web::scope("/radar")
+                        .route("/frames", web::get().to(radar::handlers::frames))
+                        .route("/forecast", web::get().to(radar::handlers::forecast))
+                        .route("/wms", web::get().to(radar::handlers::wms)),
+                ),
         )
         .service(SwaggerUi::new("/docs/{_:.*}").url("/api-doc/openapi.json", openapi))
         .service({
@@ -275,6 +289,8 @@ pub fn create_test_app_state_with(settings: Settings) -> Arc<AppState> {
         solis_cache: Cache::new(std::time::Duration::from_secs(300)),
         pv_cache: Cache::new(std::time::Duration::from_secs(60)),
         spot_cache: Cache::new(std::time::Duration::from_secs(600)),
+        radar_frames_cache: Cache::new(std::time::Duration::from_secs(60)),
+        precip_forecast_cache: Cache::new(std::time::Duration::from_secs(1800)),
         hue_events_tx,
         storage,
     })
@@ -315,6 +331,8 @@ pub async fn run_server() -> std::io::Result<()> {
         solis_cache: Cache::new(std::time::Duration::from_secs(300)),
         pv_cache: Cache::new(std::time::Duration::from_secs(60)),
         spot_cache: Cache::new(std::time::Duration::from_secs(600)),
+        radar_frames_cache: Cache::new(std::time::Duration::from_secs(60)),
+        precip_forecast_cache: Cache::new(std::time::Duration::from_secs(1800)),
         hue_events_tx: hue_events_tx.clone(),
         storage,
     });

--- a/backend/src/radar/client.rs
+++ b/backend/src/radar/client.rs
@@ -1,0 +1,122 @@
+use chrono::{DateTime, Duration, Utc};
+
+use super::models::RadarFrames;
+
+/// Fetch the WMS capabilities, read the time dimension for `layer`, and return
+/// the most recent `count` frames (ascending). Anchoring on FMI's advertised
+/// latest timestamp avoids requesting frames that don't exist yet.
+pub async fn fetch_frames(
+    client: &reqwest::Client,
+    wms_base_url: &str,
+    layer: &str,
+    count: u32,
+) -> Result<RadarFrames, Box<dyn std::error::Error + Send + Sync>> {
+    let url = format!("{wms_base_url}?service=WMS&version=1.3.0&request=GetCapabilities");
+    let caps = client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    let (latest, interval) = parse_time_extent(&caps, layer)
+        .ok_or_else(|| format!("no time extent for layer {layer}"))?;
+
+    let count = count.max(1) as i64;
+    let step = Duration::minutes(interval as i64);
+    // Build ascending: oldest first, newest (latest) last.
+    let times: Vec<String> = (0..count)
+        .rev()
+        .map(|i| format_instant(latest - step * i as i32))
+        .collect();
+
+    Ok(RadarFrames {
+        layer: layer.to_string(),
+        times,
+        interval_minutes: interval,
+    })
+}
+
+/// Format as the second-precision UTC instant FMI's WMS accepts, e.g.
+/// `2026-06-22T17:50:00Z`.
+fn format_instant(t: DateTime<Utc>) -> String {
+    t.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+/// Locate the `<Dimension name="time">…</Dimension>` belonging to `layer` and
+/// return its newest instant plus the step in minutes. The extent reads like
+/// `2026-06-15T18:00:00.000Z/2026-06-22T17:50:00.000Z/PT5M`.
+fn parse_time_extent(caps: &str, layer: &str) -> Option<(DateTime<Utc>, u32)> {
+    let name_tag = format!("<Name>{layer}</Name>");
+    let name_pos = caps.find(&name_tag)?;
+    let after = &caps[name_pos..];
+
+    let dim_pos = after.find("<Dimension name=\"time\"")?;
+    let dim = &after[dim_pos..];
+    let open_end = dim.find('>')? + 1;
+    let close = dim.find("</Dimension>")?;
+    let extent = dim[open_end..close].trim();
+
+    // Take the last comma-separated range, then split start/end/period.
+    let range = extent.rsplit(',').next()?.trim();
+    let mut parts = range.split('/');
+    let _start = parts.next()?;
+    let end = parts.next()?.trim();
+    let period = parts.next().unwrap_or("PT5M").trim();
+
+    let latest = DateTime::parse_from_rfc3339(end).ok()?.with_timezone(&Utc);
+    Some((latest, parse_iso_minutes(period)))
+}
+
+/// Parse the minute component of an ISO8601 period like `PT5M`. Defaults to 5.
+fn parse_iso_minutes(period: &str) -> u32 {
+    period
+        .strip_prefix("PT")
+        .and_then(|p| p.strip_suffix('M'))
+        .and_then(|m| m.parse().ok())
+        .unwrap_or(5)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CAPS: &str = r#"
+        <Layer><Name>Radar:other</Name></Layer>
+        <Layer>
+          <Name>Radar:suomi_dbz_eureffin</Name>
+          <Dimension name="time" default="current" units="ISO8601">2026-06-15T18:00:00.000Z/2026-06-22T17:50:00.000Z/PT5M</Dimension>
+        </Layer>
+    "#;
+
+    #[test]
+    fn parses_latest_and_interval() {
+        let (latest, interval) = parse_time_extent(CAPS, "Radar:suomi_dbz_eureffin").unwrap();
+        assert_eq!(interval, 5);
+        assert_eq!(format_instant(latest), "2026-06-22T17:50:00Z");
+    }
+
+    #[test]
+    fn frames_are_ascending_ending_at_latest() {
+        let (latest, _) = parse_time_extent(CAPS, "Radar:suomi_dbz_eureffin").unwrap();
+        let step = Duration::minutes(5);
+        let times: Vec<String> = (0..3i64)
+            .rev()
+            .map(|i| format_instant(latest - step * i as i32))
+            .collect();
+        assert_eq!(
+            times,
+            vec![
+                "2026-06-22T17:40:00Z",
+                "2026-06-22T17:45:00Z",
+                "2026-06-22T17:50:00Z",
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_layer_returns_none() {
+        assert!(parse_time_extent(CAPS, "Radar:nope").is_none());
+    }
+}

--- a/backend/src/radar/forecast.rs
+++ b/backend/src/radar/forecast.rs
@@ -1,0 +1,280 @@
+use std::io::Cursor;
+
+use chrono::{DateTime, Duration, Timelike, Utc};
+use grib::Grib2SubmessageDecoder;
+
+use super::models::{ForecastFrame, PrecipForecast};
+
+/// FMI HARMONIE Scandinavia surface producer (hourly precipitation forecast).
+const PRODUCER: &str = "harmonie_scandinavia_surface";
+/// Half-extent of the requested area around the location, in degrees. Sized to
+/// cover southern Finland (centred on the saved location). Whole-Finland would
+/// need tiling — a single lat/lon overlay misregisters over a tall span.
+const HALF_LON: f64 = 4.5;
+const HALF_LAT: f64 = 1.7;
+/// Cap on the resampled grid's longest side. High enough to keep ~native
+/// (~2.5 km) detail across the southern-Finland box; values are rounded to
+/// 0.1 mm so the payload stays modest.
+const MAX_GRID_SIDE: usize = 400;
+/// FMI's GRIB `Precipitation1h` is in metres of water; the rest of the app
+/// (and FMI's own WFS) speaks millimetres.
+const MM_PER_METRE: f32 = 1000.0;
+
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// Regular lat/lon grid geometry, read straight from the GRIB2 grid-definition
+/// section (template 3.0) so we don't need PROJ.
+struct GridGeom {
+    ni: usize,
+    nj: usize,
+    south: f64,
+    west: f64,
+    north: f64,
+    east: f64,
+    /// True when i (longitude) scans west→east.
+    i_pos: bool,
+    /// True when j (latitude) scans south→north.
+    j_pos: bool,
+}
+
+/// Fetch + decode, retrying transient upstream failures (FMI occasionally drops
+/// the connection mid-response → `hyper IncompleteMessage`, or briefly serves an
+/// XML error instead of GRIB).
+pub async fn fetch_forecast(
+    client: &reqwest::Client,
+    download_base_url: &str,
+    lat: f64,
+    lon: f64,
+    hours: u32,
+) -> Result<PrecipForecast, BoxErr> {
+    let mut last_err: Option<BoxErr> = None;
+    for attempt in 0..3 {
+        if attempt > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(300 * attempt)).await;
+        }
+        match fetch_once(client, download_base_url, lat, lon, hours).await {
+            Ok(forecast) => return Ok(forecast),
+            Err(e) => {
+                tracing::warn!("precip forecast attempt {} failed: {e}", attempt + 1);
+                last_err = Some(e);
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| "precip forecast failed".into()))
+}
+
+async fn fetch_once(
+    client: &reqwest::Client,
+    download_base_url: &str,
+    lat: f64,
+    lon: f64,
+    hours: u32,
+) -> Result<PrecipForecast, BoxErr> {
+    let (south, west, north, east) = (
+        lat - HALF_LAT,
+        lon - HALF_LON,
+        lat + HALF_LAT,
+        lon + HALF_LON,
+    );
+
+    // Forecast window: the next whole hour through +`hours`.
+    let start = Utc::now()
+        .with_minute(0)
+        .and_then(|t| t.with_second(0))
+        .and_then(|t| t.with_nanosecond(0))
+        .unwrap_or_else(Utc::now)
+        + Duration::hours(1);
+    let end = start + Duration::hours(hours as i64 - 1);
+
+    let url = format!(
+        "{download_base_url}?producer={PRODUCER}&param=Precipitation1h\
+         &bbox={west},{south},{east},{north}\
+         &starttime={}&endtime={}&format=grib2&projection=EPSG:4326&levels=0&timestep=60",
+        fmt(start),
+        fmt(end),
+    );
+
+    let bytes = client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+
+    if bytes.len() < 16 || &bytes[0..4] != b"GRIB" {
+        return Err("FMI did not return a GRIB2 payload".into());
+    }
+
+    let geom = parse_grid_geom(&bytes).ok_or("could not read GRIB grid definition")?;
+    let (cols, rows, stride) = resampled_dims(geom.ni, geom.nj);
+
+    let grib2 = grib::from_reader(Cursor::new(&bytes[..]))?;
+    let mut frames = Vec::new();
+    for (i, (_idx, submessage)) in grib2.iter().enumerate() {
+        if i >= hours as usize {
+            break;
+        }
+        let decoder = Grib2SubmessageDecoder::from(submessage)?;
+        let raw: Vec<f32> = decoder.dispatch()?.collect();
+
+        let mut values = Vec::with_capacity(rows * cols);
+        let mut max = 0.0f32;
+        for r in 0..rows {
+            for c in 0..cols {
+                // Block-MAX over each stride×stride native block so narrow
+                // showers survive downsampling (striding would step over them).
+                let mut peak = 0.0f32;
+                for dr in 0..stride {
+                    for dc in 0..stride {
+                        let (sr, sc) = (r * stride + dr, c * stride + dc);
+                        if sr < geom.nj && sc < geom.ni {
+                            peak = peak.max(sample(&raw, &geom, sr, sc));
+                        }
+                    }
+                }
+                // FMI's GRIB encodes precipitation in metres; convert to mm and
+                // round to 0.1 mm (finer than the colour bins need, compact JSON).
+                let v = (peak * MM_PER_METRE * 10.0).round() / 10.0;
+                max = max.max(v);
+                values.push(v);
+            }
+        }
+        frames.push(ForecastFrame {
+            time: fmt(start + Duration::hours(i as i64)),
+            max,
+            values,
+        });
+    }
+
+    if frames.is_empty() {
+        return Err("GRIB2 contained no forecast steps".into());
+    }
+
+    Ok(PrecipForecast {
+        bbox: [geom.south, geom.west, geom.north, geom.east],
+        cols,
+        rows,
+        unit: "mm/h".to_string(),
+        frames,
+    })
+}
+
+fn fmt(t: DateTime<Utc>) -> String {
+    t.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+/// North-up (row 0 = north, col 0 = west) lookup into the GRIB scan order,
+/// honouring the scanning-mode flags. Missing/negative values clamp to 0.
+fn sample(raw: &[f32], g: &GridGeom, row_from_north: usize, col_from_west: usize) -> f32 {
+    let i = if g.i_pos {
+        col_from_west
+    } else {
+        g.ni - 1 - col_from_west
+    };
+    let j = if g.j_pos {
+        g.nj - 1 - row_from_north
+    } else {
+        row_from_north
+    };
+    let k = j * g.ni + i;
+    raw.get(k)
+        .copied()
+        .filter(|v| v.is_finite())
+        .map(|v| v.max(0.0))
+        .unwrap_or(0.0)
+}
+
+fn resampled_dims(ni: usize, nj: usize) -> (usize, usize, usize) {
+    let stride = (ni.max(nj)).div_ceil(MAX_GRID_SIDE).max(1);
+    let cols = ni.div_ceil(stride);
+    let rows = nj.div_ceil(stride);
+    (cols, rows, stride)
+}
+
+/// Parse the first grid-definition section (GRIB2 section 3, template 3.0).
+fn parse_grid_geom(buf: &[u8]) -> Option<GridGeom> {
+    let mut p = 16; // skip the 16-byte indicator section (section 0)
+    while p + 5 <= buf.len() {
+        let seclen = u32be(buf, p)? as usize;
+        let secnum = buf[p + 4];
+        if secnum == 3 {
+            if u16be(buf, p + 12)? != 0 {
+                return None; // not a lat/lon (template 3.0) grid
+            }
+            let ni = u32be(buf, p + 30)? as usize;
+            let nj = u32be(buf, p + 34)? as usize;
+            let la1 = signed_micro(buf, p + 46)?;
+            let lo1 = signed_micro(buf, p + 50)?;
+            let la2 = signed_micro(buf, p + 55)?;
+            let lo2 = signed_micro(buf, p + 59)?;
+            let scan = *buf.get(p + 71)?;
+            return Some(GridGeom {
+                ni,
+                nj,
+                south: la1.min(la2),
+                west: lo1.min(lo2),
+                north: la1.max(la2),
+                east: lo1.max(lo2),
+                i_pos: scan & 0x80 == 0,
+                j_pos: scan & 0x40 != 0,
+            });
+        }
+        if seclen == 0 {
+            break;
+        }
+        p += seclen;
+    }
+    None
+}
+
+fn u16be(b: &[u8], o: usize) -> Option<u16> {
+    Some(u16::from_be_bytes(b.get(o..o + 2)?.try_into().ok()?))
+}
+
+fn u32be(b: &[u8], o: usize) -> Option<u32> {
+    Some(u32::from_be_bytes(b.get(o..o + 4)?.try_into().ok()?))
+}
+
+/// GRIB2 angles are sign-magnitude integers in micro-degrees.
+fn signed_micro(b: &[u8], o: usize) -> Option<f64> {
+    let raw = u32be(b, o)?;
+    let mag = (raw & 0x7fff_ffff) as f64 / 1e6;
+    Some(if raw & 0x8000_0000 != 0 { -mag } else { mag })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resample_keeps_small_grids_intact() {
+        assert_eq!(resampled_dims(89, 45), (89, 45, 1));
+    }
+
+    #[test]
+    fn resample_coarsens_large_grids() {
+        let (cols, rows, stride) = resampled_dims(900, 500);
+        assert!(stride >= 2);
+        assert!(cols <= MAX_GRID_SIDE && rows <= MAX_GRID_SIDE);
+    }
+
+    #[test]
+    fn sample_orients_south_west_first_scan_to_north_up() {
+        // 2x2 grid scanning west→east, south→north: raw = [SW, SE, NW, NE]
+        let g = GridGeom {
+            ni: 2,
+            nj: 2,
+            south: 0.0,
+            west: 0.0,
+            north: 1.0,
+            east: 1.0,
+            i_pos: true,
+            j_pos: true,
+        };
+        let raw = [10.0, 20.0, 30.0, 40.0];
+        assert_eq!(sample(&raw, &g, 0, 0), 30.0); // north-west
+        assert_eq!(sample(&raw, &g, 0, 1), 40.0); // north-east
+        assert_eq!(sample(&raw, &g, 1, 0), 10.0); // south-west
+    }
+}

--- a/backend/src/radar/handlers.rs
+++ b/backend/src/radar/handlers.rs
@@ -1,0 +1,151 @@
+use std::sync::Arc;
+
+use actix_web::{http::StatusCode, web, HttpRequest, HttpResponse};
+use serde::Deserialize;
+
+use super::models::DEFAULT_LAYER;
+use crate::AppState;
+
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct ForecastQuery {
+    /// Latitude of the map centre.
+    pub lat: f64,
+    /// Longitude of the map centre.
+    pub lon: f64,
+    /// Forecast horizon in hours (default 12, max 24).
+    pub hours: Option<u32>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/radar/forecast",
+    params(ForecastQuery),
+    responses(
+        (status = 200, description = "Gridded precipitation forecast", body = super::models::PrecipForecast),
+        (status = 502, description = "Failed to fetch or decode forecast")
+    )
+)]
+pub async fn forecast(
+    state: web::Data<Arc<AppState>>,
+    query: web::Query<ForecastQuery>,
+) -> HttpResponse {
+    let hours = query.hours.unwrap_or(12).clamp(1, 24);
+    // Round the location into the cache key so small map nudges reuse the grid.
+    let key = format!("{:.2},{:.2}:{hours}", query.lat, query.lon);
+
+    if let Some(cached) = state.precip_forecast_cache.get(&key).await {
+        return HttpResponse::Ok().json(cached);
+    }
+
+    match super::forecast::fetch_forecast(
+        &state.http_client,
+        &state.settings.fmi_download_base_url,
+        query.lat,
+        query.lon,
+        hours,
+    )
+    .await
+    {
+        Ok(forecast) => {
+            state.precip_forecast_cache.set(key, forecast.clone()).await;
+            HttpResponse::Ok().json(forecast)
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch precip forecast: {e}");
+            if let Some(stale) = state.precip_forecast_cache.get_stale(&key).await {
+                HttpResponse::Ok().json(stale)
+            } else {
+                HttpResponse::BadGateway()
+                    .json(serde_json::json!({"error": "No forecast available"}))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct FramesQuery {
+    /// WMS layer to animate (defaults to the nationwide reflectivity composite).
+    pub layer: Option<String>,
+    /// Number of frames to return (default 12, max 48).
+    pub count: Option<u32>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/radar/frames",
+    params(FramesQuery),
+    responses(
+        (status = 200, description = "Radar animation frame timestamps", body = super::models::RadarFrames),
+        (status = 502, description = "Failed to fetch radar capabilities")
+    )
+)]
+pub async fn frames(
+    state: web::Data<Arc<AppState>>,
+    query: web::Query<FramesQuery>,
+) -> HttpResponse {
+    let layer = query.layer.as_deref().unwrap_or(DEFAULT_LAYER).to_string();
+    let count = query.count.unwrap_or(12).clamp(1, 48);
+    let key = format!("{layer}:{count}");
+
+    if let Some(cached) = state.radar_frames_cache.get(&key).await {
+        return HttpResponse::Ok().json(cached);
+    }
+
+    match super::client::fetch_frames(
+        &state.http_client,
+        &state.settings.fmi_wms_base_url,
+        &layer,
+        count,
+    )
+    .await
+    {
+        Ok(frames) => {
+            state.radar_frames_cache.set(key, frames.clone()).await;
+            HttpResponse::Ok().json(frames)
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch radar frames: {e}");
+            if let Some(stale) = state.radar_frames_cache.get_stale(&key).await {
+                HttpResponse::Ok().json(stale)
+            } else {
+                HttpResponse::BadGateway()
+                    .json(serde_json::json!({"error": "No radar frames available"}))
+            }
+        }
+    }
+}
+
+/// Transparent proxy for FMI WMS `GetMap` tiles. The frontend's Leaflet WMS
+/// layer points here; we forward the query string verbatim to a single fixed
+/// upstream (no open proxy) and stream the image bytes back. Tiles are cached
+/// by the browser/Leaflet, so no server-side tile cache is needed.
+pub async fn wms(state: web::Data<Arc<AppState>>, req: HttpRequest) -> HttpResponse {
+    let url = format!("{}?{}", state.settings.fmi_wms_base_url, req.query_string());
+
+    match state.http_client.get(&url).send().await {
+        Ok(resp) => {
+            let status =
+                StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+            let content_type = resp
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("image/png")
+                .to_string();
+            match resp.bytes().await {
+                Ok(bytes) => HttpResponse::build(status)
+                    .insert_header(("Cache-Control", "public, max-age=300"))
+                    .content_type(content_type)
+                    .body(bytes),
+                Err(e) => {
+                    tracing::error!("Failed to read radar tile body: {e}");
+                    HttpResponse::BadGateway().finish()
+                }
+            }
+        }
+        Err(e) => {
+            tracing::error!("Failed to proxy radar tile: {e}");
+            HttpResponse::BadGateway().finish()
+        }
+    }
+}

--- a/backend/src/radar/mod.rs
+++ b/backend/src/radar/mod.rs
@@ -1,0 +1,4 @@
+pub mod client;
+pub mod forecast;
+pub mod handlers;
+pub mod models;

--- a/backend/src/radar/models.rs
+++ b/backend/src/radar/models.rs
@@ -1,0 +1,47 @@
+use serde::Serialize;
+
+/// The default FMI radar layer: nationwide reflectivity composite (dBZ),
+/// the classic rain-radar look. Updated every 5 minutes.
+pub const DEFAULT_LAYER: &str = "Radar:suomi_dbz_eureffin";
+
+/// Animation frames for the rain radar. `times` is ascending (oldest first),
+/// formatted as the ISO8601 instants FMI's WMS `time` dimension accepts.
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct RadarFrames {
+    /// The WMS layer these frames belong to.
+    pub layer: String,
+    /// Frame timestamps, ascending (e.g. `2026-06-22T17:50:00Z`).
+    pub times: Vec<String>,
+    /// Spacing between frames in minutes.
+    #[serde(rename = "intervalMinutes")]
+    pub interval_minutes: u32,
+}
+
+/// Gridded precipitation forecast (FMI HARMONIE), decoded from GRIB2 and
+/// resampled to a coarse north-up lat/lon grid the frontend renders as a heat
+/// overlay. The grid is regular in EPSG:4326, so `bbox` + `rows`/`cols` place
+/// every cell.
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct PrecipForecast {
+    /// Grid extent as `[south, west, north, east]` in degrees (WGS84).
+    pub bbox: [f64; 4],
+    /// Columns (west→east) in each frame's `values`.
+    pub cols: usize,
+    /// Rows (north→south) in each frame's `values`.
+    pub rows: usize,
+    /// Value unit, e.g. `mm/h`.
+    pub unit: String,
+    /// Forecast steps, ascending in time.
+    pub frames: Vec<ForecastFrame>,
+}
+
+/// One forecast time step.
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct ForecastFrame {
+    /// Valid time, e.g. `2026-06-22T19:00:00Z`.
+    pub time: String,
+    /// Peak value across the grid (lets the frontend skip empty frames cheaply).
+    pub max: f32,
+    /// Row-major, north-up (row 0 = north), west→east. Length = `rows * cols`.
+    pub values: Vec<f32>,
+}

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -4,6 +4,8 @@ pub struct Settings {
     pub tomorrow_io_api_key: String,
     pub tomorrow_io_base_url: String,
     pub fmi_base_url: String,
+    pub fmi_wms_base_url: String,
+    pub fmi_download_base_url: String,
     pub language: String,
     pub hue_bridge_address: String,
     pub hue_bridge_user: String,
@@ -27,6 +29,8 @@ impl Settings {
             tomorrow_io_api_key: String::new(),
             tomorrow_io_base_url: "https://api.tomorrow.io".into(),
             fmi_base_url: "https://opendata.fmi.fi/wfs".into(),
+            fmi_wms_base_url: "https://openwms.fmi.fi/geoserver/wms".into(),
+            fmi_download_base_url: "https://opendata.fmi.fi/download".into(),
             language: "fi".into(),
             hue_bridge_address: String::new(),
             hue_bridge_user: String::new(),
@@ -50,6 +54,10 @@ impl Settings {
                 .unwrap_or_else(|_| "https://api.tomorrow.io".into()),
             fmi_base_url: env::var("FMI_BASE_URL")
                 .unwrap_or_else(|_| "https://opendata.fmi.fi/wfs".into()),
+            fmi_wms_base_url: env::var("FMI_WMS_BASE_URL")
+                .unwrap_or_else(|_| "https://openwms.fmi.fi/geoserver/wms".into()),
+            fmi_download_base_url: env::var("FMI_DOWNLOAD_BASE_URL")
+                .unwrap_or_else(|_| "https://opendata.fmi.fi/download".into()),
             language: env::var("LANGUAGE").unwrap_or_else(|_| "fi".into()),
             hue_bridge_address: env::var("HUE_BRIDGE_ADDRESS").unwrap_or_default(),
             hue_bridge_user: env::var("HUE_BRIDGE_USER").unwrap_or_default(),

--- a/backend/tests/smoke.rs
+++ b/backend/tests/smoke.rs
@@ -47,6 +47,8 @@ fn test_settings_with_mock(mock_url: &str) -> Settings {
         tomorrow_io_api_key: "test-key".into(),
         tomorrow_io_base_url: mock_url.into(),
         fmi_base_url: mock_url.into(),
+        fmi_wms_base_url: mock_url.into(),
+        fmi_download_base_url: mock_url.into(),
         language: "fi".into(),
         hue_bridge_address: mock_url.into(),
         hue_bridge_user: "test-user".into(),

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "chartjs-plugin-datalabels": "^2.2.0",
     "classnames": "^2.5.1",
     "date-fns": "^4.4.0",
+    "leaflet": "^1.9.4",
     "lucide-react": "^1.18.0",
     "react": "^19.2.7",
     "react-chartjs-2": "^5.3.1",
@@ -33,6 +34,7 @@
   },
   "devDependencies": {
     "@anarkisti/eslint-config": "^1.1.0",
+    "@types/leaflet": "^1.9.21",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { css, useTheme } from "@emotion/react";
-import { useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 
 import { api } from "./api";
 import CurrentTime from "./components/CurrentTime";
@@ -19,6 +19,9 @@ import TemperatureBox from "./components/TemperatureBox";
 import Wordmark from "./components/Wordmark";
 import { mq } from "./mq";
 import { type HueLiveEvent, type Response, type Sensor } from "./types/hue";
+
+// Leaflet is heavy; only pull it in when the radar tab is opened.
+const RainMap = lazy(() => import("./components/RainMap"));
 
 const applyEvent = (data: Response, event: HueLiveEvent): Response => {
   switch (event.type) {
@@ -86,6 +89,7 @@ type View =
   | "energy"
   | "lights"
   | "motion"
+  | "radar"
   | "history"
   | "settings";
 
@@ -94,6 +98,7 @@ const VIEWS: { id: View; icon: string }[] = [
   { id: "energy", icon: "bolt" },
   { id: "lights", icon: "lightbulb" },
   { id: "motion", icon: "directions_run" },
+  { id: "radar", icon: "radar" },
   { id: "history", icon: "timeline" },
   { id: "settings", icon: "settings" },
 ];
@@ -347,6 +352,12 @@ const App = () => {
                 sensors={outside.concat(insideCold).concat(inside)}
                 error={!!error}
               />
+            )}
+
+            {view === "radar" && (
+              <Suspense fallback={null}>
+                <RainMap css={{ gridColumn: "1 / span 4" }} />
+              </Suspense>
             )}
 
             {view === "history" && (

--- a/frontend/src/components/RainMap.tsx
+++ b/frontend/src/components/RainMap.tsx
@@ -1,0 +1,605 @@
+import "leaflet/dist/leaflet.css";
+
+import { useTheme } from "@emotion/react";
+import { format } from "date-fns";
+import * as L from "leaflet";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import useSWR from "swr";
+
+import { api, jsonFetcher } from "../api";
+import useLocationSettings from "../hooks/useLocationSettings";
+import { mq } from "../mq";
+import Icon from "./Icon";
+
+type RadarFrames = {
+  layer: string;
+  times: string[];
+  intervalMinutes: number;
+};
+
+type ForecastFrame = { time: string; max: number; values: number[] };
+type PrecipForecast = {
+  bbox: [number, number, number, number]; // [south, west, north, east]
+  cols: number;
+  rows: number;
+  unit: string;
+  frames: ForecastFrame[];
+};
+
+type Frame = {
+  kind: "observed" | "forecast";
+  time: string;
+  layer: L.TileLayer.WMS | L.ImageOverlay;
+  baseOpacity: number;
+};
+
+const FRAME_COUNT = 12; // observed radar frames (5-min steps → last hour)
+const FORECAST_HOURS = 12; // forecast frames (hourly)
+const DEFAULT_ZOOM = 8;
+const RADAR_OPACITY = 0.75;
+const FORECAST_OPACITY = 0.6;
+const PLAY_MS = 450; // per-frame while playing
+const HOLD_MS = 1100; // linger on the last frame before looping
+const LONG_PRESS_MS = 300; // hold before map-swipe scrubbing engages
+const PAN_THRESHOLD = 10; // px of movement that counts as a pan, not a press
+const PX_PER_FRAME = 26; // swipe sensitivity once scrubbing
+
+// Precipitation colour ramp (mm/h → RGB). Shared by the heat overlay and legend.
+const PRECIP_STOPS: { v: number; c: [number, number, number] }[] = [
+  { v: 0.1, c: [150, 210, 255] },
+  { v: 0.5, c: [90, 170, 245] },
+  { v: 1, c: [50, 120, 230] },
+  { v: 2, c: [40, 80, 200] },
+  { v: 4, c: [60, 180, 90] },
+  { v: 7, c: [220, 205, 50] },
+  { v: 12, c: [240, 140, 30] },
+  { v: 20, c: [225, 45, 45] },
+  { v: 40, c: [170, 0, 110] },
+];
+
+const precipColor = (v: number): [number, number, number, number] => {
+  if (!(v >= 0.1)) return [0, 0, 0, 0];
+  let c = PRECIP_STOPS[0].c;
+  for (const s of PRECIP_STOPS) if (v >= s.v) c = s.c;
+  return [c[0], c[1], c[2], 185];
+};
+
+/** Paint one forecast grid into a canvas and wrap it as a geo-placed overlay. */
+const buildForecastOverlay = (
+  fc: PrecipForecast,
+  frame: ForecastFrame,
+): L.ImageOverlay => {
+  const { cols, rows, bbox } = fc;
+  const canvas = document.createElement("canvas");
+  canvas.width = cols;
+  canvas.height = rows;
+  const ctx = canvas.getContext("2d")!;
+  const img = ctx.createImageData(cols, rows);
+  for (let p = 0; p < cols * rows; p++) {
+    const [r, g, b, a] = precipColor(frame.values[p]);
+    const o = p * 4;
+    img.data[o] = r;
+    img.data[o + 1] = g;
+    img.data[o + 2] = b;
+    img.data[o + 3] = a;
+  }
+  ctx.putImageData(img, 0, 0);
+  const [south, west, north, east] = bbox;
+  return L.imageOverlay(
+    canvas.toDataURL(),
+    [
+      [south, west],
+      [north, east],
+    ],
+    { opacity: 0, interactive: false },
+  );
+};
+
+const RainMap = ({ className }: { className?: string }) => {
+  const theme = useTheme();
+  const { location } = useLocationSettings();
+
+  const { data: obsData, error: obsError } = useSWR<RadarFrames>(
+    api(`/api/radar/frames?count=${FRAME_COUNT}`),
+    jsonFetcher,
+    { refreshInterval: 60_000, shouldRetryOnError: false },
+  );
+  const { data: fcData, error: fcError } = useSWR<PrecipForecast>(
+    location
+      ? api(
+          `/api/radar/forecast?lat=${location.lat}&lon=${location.lon}&hours=${FORECAST_HOURS}`,
+        )
+      : null,
+    jsonFetcher,
+    // The FMI GRIB fetch can fail transiently (502); retry a few times rather
+    // than leaving the timeline stuck at "now" until the next refresh.
+    { refreshInterval: 600_000, errorRetryCount: 4, errorRetryInterval: 5_000 },
+  );
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<L.Map | null>(null);
+  const baseRef = useRef<L.TileLayer | null>(null);
+  const framesRef = useRef<Frame[]>([]);
+  const [ready, setReady] = useState(false);
+
+  const [index, setIndex] = useState(0);
+  const [playing, setPlaying] = useState(true);
+
+  // Frame metadata (kind + time), derived so labels/slider re-render in step
+  // with the layers built in the effect below from the same two sources.
+  const timeline = useMemo(() => {
+    const obs = (obsData?.times ?? []).map(
+      (time) => ({ kind: "observed", time }) as const,
+    );
+    const fc = (fcData?.frames ?? []).map(
+      (f) => ({ kind: "forecast", time: f.time }) as const,
+    );
+    return [...obs, ...fc];
+  }, [obsData, fcData]);
+
+  const observedCount = obsData?.times.length ?? 0;
+  const nowIndex = observedCount - 1;
+  const lastIndex = timeline.length - 1;
+
+  // --- map lifecycle (re-created if the location changes) ---
+  useEffect(() => {
+    if (!location || !containerRef.current || mapRef.current) return;
+    const map = L.map(containerRef.current, {
+      center: [location.lat, location.lon],
+      zoom: DEFAULT_ZOOM,
+      zoomControl: true,
+      attributionControl: true,
+    });
+    map.attributionControl.addAttribution(
+      'Sää © <a href="https://en.ilmatieteenlaitos.fi/open-data">FMI</a>',
+    );
+    mapRef.current = map;
+    // Leaflet mis-sizes if the container grew after init; defer sizing and the
+    // readiness signal so dependent effects see a correctly-sized map.
+    const sizeTimer = setTimeout(() => {
+      map.invalidateSize();
+      setReady(true);
+    }, 0);
+    return () => {
+      clearTimeout(sizeTimer);
+      map.remove();
+      mapRef.current = null;
+      baseRef.current = null;
+      framesRef.current = [];
+      setReady(false);
+    };
+  }, [location]);
+
+  // --- base map, swapped with the colour scheme ---
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !ready) return;
+    if (baseRef.current) map.removeLayer(baseRef.current);
+    const variant = theme.mode === "dark" ? "dark_all" : "light_all";
+    const base = L.tileLayer(
+      `https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`,
+      {
+        subdomains: "abcd",
+        maxZoom: 19,
+        attribution:
+          '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> © <a href="https://carto.com/attributions">CARTO</a>',
+      },
+    );
+    base.addTo(map);
+    base.bringToBack();
+    baseRef.current = base;
+  }, [theme.mode, ready]);
+
+  // --- build the unified layer stack: observed WMS tiles + forecast heat ---
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !ready) return;
+    framesRef.current.forEach((f) => map.removeLayer(f.layer));
+
+    const built: Frame[] = [];
+    if (obsData) {
+      for (const time of obsData.times) {
+        const layer = L.tileLayer
+          .wms(api("/api/radar/wms"), {
+            layers: obsData.layer,
+            format: "image/png",
+            transparent: true,
+            version: "1.3.0",
+            opacity: 0,
+            time,
+          } as unknown as L.WMSOptions)
+          .addTo(map);
+        built.push({
+          kind: "observed",
+          time,
+          layer,
+          baseOpacity: RADAR_OPACITY,
+        });
+      }
+    }
+    if (fcData && fcData.frames.length > 0) {
+      for (const frame of fcData.frames) {
+        const layer = buildForecastOverlay(fcData, frame).addTo(map);
+        built.push({
+          kind: "forecast",
+          time: frame.time,
+          layer,
+          baseOpacity: FORECAST_OPACITY,
+        });
+      }
+    }
+    framesRef.current = built;
+
+    // Show "now" (last observed frame) immediately to avoid a blank flash,
+    // then sync the index to it on the next tick.
+    const startIdx = Math.max(0, (obsData?.times.length ?? 0) - 1);
+    built[startIdx]?.layer.setOpacity(built[startIdx].baseOpacity);
+    const indexTimer = setTimeout(() => setIndex(startIdx), 0);
+    return () => {
+      clearTimeout(indexTimer);
+      built.forEach((f) => map.removeLayer(f.layer));
+      framesRef.current = [];
+    };
+  }, [obsData, fcData, ready]);
+
+  // --- show only the active frame ---
+  useEffect(() => {
+    framesRef.current.forEach((f, i) =>
+      f.layer.setOpacity(i === index ? f.baseOpacity : 0),
+    );
+  }, [index, timeline]);
+
+  // --- playback loop ---
+  useEffect(() => {
+    if (!playing || timeline.length === 0) return;
+    const delay = index >= lastIndex ? HOLD_MS : PLAY_MS;
+    const timer = setTimeout(
+      () => setIndex((i) => (i + 1) % timeline.length),
+      delay,
+    );
+    return () => clearTimeout(timer);
+  }, [playing, index, lastIndex, timeline.length]);
+
+  const scrubTo = useCallback((i: number) => {
+    const len = framesRef.current.length;
+    if (len === 0) return;
+    setIndex(Math.max(0, Math.min(len - 1, i)));
+  }, []);
+
+  const recenter = useCallback(() => {
+    const map = mapRef.current;
+    if (map && location)
+      map.setView([location.lat, location.lon], DEFAULT_ZOOM, {
+        animate: true,
+      });
+  }, [location]);
+
+  // --- long-press-then-swipe on the map to scrub frame by frame ---
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !ready) return;
+    const el = map.getContainer();
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let engaged = false;
+    let startX = 0;
+    let baseIndex = 0;
+
+    const cancelTimer = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+    const release = () => {
+      cancelTimer();
+      if (engaged) {
+        engaged = false;
+        map.dragging.enable();
+      }
+    };
+
+    const onDown = (e: PointerEvent) => {
+      if (e.pointerType === "mouse" && e.button !== 0) return;
+      startX = e.clientX;
+      cancelTimer();
+      timer = setTimeout(() => {
+        engaged = true;
+        timer = null;
+        baseIndex = index;
+        startX = e.clientX;
+        map.dragging.disable();
+        setPlaying(false);
+      }, LONG_PRESS_MS);
+    };
+    const onMove = (e: PointerEvent) => {
+      if (engaged) {
+        const steps = Math.round((e.clientX - startX) / PX_PER_FRAME);
+        scrubTo(baseIndex + steps);
+      } else if (Math.abs(e.clientX - startX) > PAN_THRESHOLD) {
+        // a real pan — let Leaflet have it
+        cancelTimer();
+      }
+    };
+
+    el.addEventListener("pointerdown", onDown);
+    el.addEventListener("pointermove", onMove);
+    el.addEventListener("pointerup", release);
+    el.addEventListener("pointercancel", release);
+    el.addEventListener("pointerleave", release);
+    return () => {
+      release();
+      el.removeEventListener("pointerdown", onDown);
+      el.removeEventListener("pointermove", onMove);
+      el.removeEventListener("pointerup", release);
+      el.removeEventListener("pointercancel", release);
+      el.removeEventListener("pointerleave", release);
+    };
+  }, [ready, index, scrubTo]);
+
+  const active = timeline[index];
+  const obsInterval = obsData?.intervalMinutes ?? 5;
+  let relText = "";
+  let relColor = theme.colors.text.muted;
+  if (active?.kind === "observed") {
+    const back = nowIndex - index;
+    if (back <= 0) {
+      relText = "nyt";
+      relColor = theme.colors.activity.on;
+    } else {
+      relText = `−${back * obsInterval} min`;
+    }
+  } else if (active?.kind === "forecast") {
+    relText = `+${index - nowIndex} h`;
+    relColor = theme.colors.cool;
+  }
+  const activeForecastDry =
+    active?.kind === "forecast" &&
+    (fcData?.frames[index - observedCount]?.max ?? 0) === 0;
+
+  const legendGradient = PRECIP_STOPS.map(
+    (s, i) =>
+      `rgb(${s.c[0]},${s.c[1]},${s.c[2]}) ${(i / (PRECIP_STOPS.length - 1)) * 100}%`,
+  ).join(", ");
+
+  const overlayPanel =
+    theme.mode === "dark" ? "rgba(37,37,37,0.9)" : "rgba(255,255,255,0.9)";
+
+  if (!location) {
+    return (
+      <div
+        className={className}
+        css={{
+          backgroundColor: theme.colors.background.main,
+          boxShadow: theme.shadows.main,
+          borderRadius: theme.border.radius,
+          padding: "2em",
+          textAlign: "center",
+          color: theme.colors.text.muted,
+          ...theme.typography.body2,
+        }}
+      >
+        Aseta sijainti asetuksista nähdäksesi sadetutkan.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      css={{
+        position: "relative",
+        borderRadius: theme.border.radius,
+        overflow: "hidden",
+        boxShadow: theme.shadows.main,
+        height: "72vh",
+        minHeight: 420,
+        [mq[0]]: { height: "70vh", minHeight: 360 },
+      }}
+    >
+      <div
+        ref={containerRef}
+        css={{ position: "absolute", inset: 0, zIndex: 0 }}
+      />
+
+      {/* precipitation legend (top-centre, clear of the left zoom + right recenter) */}
+      {fcData && (
+        <div
+          css={{
+            position: "absolute",
+            top: 12,
+            left: "50%",
+            transform: "translateX(-50%)",
+            zIndex: 1000,
+            padding: "6px 8px",
+            borderRadius: theme.border.radius,
+            backgroundColor: overlayPanel,
+            boxShadow: theme.shadows.main,
+            color: theme.colors.text.muted,
+          }}
+        >
+          <div
+            css={{
+              width: 132,
+              height: 7,
+              borderRadius: 4,
+              background: `linear-gradient(to right, ${legendGradient})`,
+            }}
+          />
+          <div
+            css={{
+              display: "flex",
+              justifyContent: "space-between",
+              ...theme.typography.caption,
+              fontSize: 11,
+              marginTop: 2,
+            }}
+          >
+            <span>kevyt</span>
+            <span>sade</span>
+            <span>rankka</span>
+          </div>
+        </div>
+      )}
+
+      {/* recenter to the saved location */}
+      <button
+        onClick={recenter}
+        aria-label="Keskitä sijaintiin"
+        css={{
+          position: "absolute",
+          top: 12,
+          right: 12,
+          zIndex: 1000,
+          display: "flex",
+          padding: 8,
+          cursor: "pointer",
+          border: "none",
+          borderRadius: theme.border.radius,
+          color: theme.colors.text.main,
+          backgroundColor: overlayPanel,
+          boxShadow: theme.shadows.main,
+        }}
+      >
+        <Icon size={22}>my_location</Icon>
+      </button>
+
+      {/* "no rain forecast" hint keeps a blank forecast frame from looking broken */}
+      {activeForecastDry && (
+        <div
+          css={{
+            position: "absolute",
+            top: 56,
+            left: "50%",
+            transform: "translateX(-50%)",
+            zIndex: 1000,
+            padding: "4px 10px",
+            borderRadius: theme.border.radius,
+            backgroundColor: overlayPanel,
+            ...theme.typography.caption,
+            color: theme.colors.text.muted,
+          }}
+        >
+          ei sadetta ennusteessa
+        </div>
+      )}
+
+      {/* control bar */}
+      <div
+        css={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          zIndex: 1000,
+          display: "flex",
+          alignItems: "center",
+          gap: 14,
+          padding: "12px 16px",
+          background:
+            theme.mode === "dark"
+              ? "linear-gradient(to top, rgba(15,15,15,0.85), rgba(15,15,15,0))"
+              : "linear-gradient(to top, rgba(255,255,255,0.9), rgba(255,255,255,0))",
+          color: theme.colors.text.main,
+        }}
+      >
+        <button
+          onClick={() => setPlaying((p) => !p)}
+          aria-label={playing ? "Pysäytä" : "Toista"}
+          css={{
+            cursor: "pointer",
+            border: "none",
+            background: "transparent",
+            color: theme.colors.activity.on,
+            display: "flex",
+            padding: 4,
+          }}
+        >
+          <Icon size={30}>{playing ? "pause_circle" : "play_circle"}</Icon>
+        </button>
+
+        <div
+          css={{
+            position: "relative",
+            flex: 1,
+            minWidth: 0,
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <input
+            type="range"
+            min={0}
+            max={Math.max(0, lastIndex)}
+            value={index}
+            onChange={(e) => {
+              setPlaying(false);
+              scrubTo(Number(e.target.value));
+            }}
+            css={{
+              width: "100%",
+              accentColor: theme.colors.activity.on,
+              cursor: "pointer",
+            }}
+          />
+          {/* "now" divider between observed and forecast */}
+          {observedCount > 0 && observedCount <= lastIndex && (
+            <div
+              css={{
+                position: "absolute",
+                left: `${(nowIndex / lastIndex) * 100}%`,
+                top: -2,
+                bottom: -2,
+                width: 2,
+                transform: "translateX(-1px)",
+                backgroundColor: theme.colors.text.main,
+                opacity: 0.45,
+                pointerEvents: "none",
+              }}
+            />
+          )}
+        </div>
+
+        <div
+          css={{
+            flexShrink: 0,
+            textAlign: "right",
+            minWidth: 70,
+            lineHeight: 1.1,
+          }}
+        >
+          <div
+            css={{
+              ...theme.typography.label,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {active ? format(new Date(active.time), "HH:mm") : "––:––"}
+          </div>
+          <div css={{ ...theme.typography.caption, color: relColor }}>
+            {relText}
+          </div>
+        </div>
+      </div>
+
+      {obsError && fcError && !obsData && !fcData && (
+        <div
+          css={{
+            position: "absolute",
+            top: 12,
+            left: 0,
+            right: 0,
+            zIndex: 1000,
+            textAlign: "center",
+            ...theme.typography.caption,
+            color: theme.colors.text.muted,
+          }}
+        >
+          Sadetutka ei juuri nyt saatavilla
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RainMap;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1032,10 +1032,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/geojson@npm:*":
+  version: 7946.0.16
+  resolution: "@types/geojson@npm:7946.0.16"
+  checksum: 10/34d07421bdd60e7b99fa265441d17ac6e9aef48e3ce22d04324127d0de1daf7fbaa0bd3be1cece2092eb6995f21da84afa5231e24621a2910ff7340bc98f496f
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.15":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10/1a3c3e06236e4c4aab89499c428d585527ce50c24fe8259e8b3926d3df4cfbbbcf306cfc73ddfb66cbafc973116efd15967020b0f738f63e09e64c7d260519e7
+  languageName: node
+  linkType: hard
+
+"@types/leaflet@npm:^1.9.21":
+  version: 1.9.21
+  resolution: "@types/leaflet@npm:1.9.21"
+  dependencies:
+    "@types/geojson": "npm:*"
+  checksum: 10/a02eff00db3cbc374c67fa7c0df6c564918482fa00407146bfea19f92600a4009f39af7bb9e3face39845979c133bb67b5bd972472720beef1f285596f47a6d1
   languageName: node
   linkType: hard
 
@@ -2603,6 +2619,13 @@ __metadata:
   version: 0.37.0
   resolution: "known-css-properties@npm:0.37.0"
   checksum: 10/9bddf2eb980f707567e3fbf8f2daaca27f5d544f4a49eab26d696ae33f54410f82f0a3032097b083d9e889e285586696c7b4324e6393103e7d71a46ca4438bfd
+  languageName: node
+  linkType: hard
+
+"leaflet@npm:^1.9.4":
+  version: 1.9.4
+  resolution: "leaflet@npm:1.9.4"
+  checksum: 10/7b6a74d503980961a85bdabebf9d1162c26db0e88195800ceea311682b653d621718f2ada3c9aab903a735af9862c9ae278ba550d4429acbd954d43449cd0d77
   languageName: node
   linkType: hard
 
@@ -4215,6 +4238,7 @@ __metadata:
     "@anarkisti/eslint-config": "npm:^1.1.0"
     "@emotion/react": "npm:^11.14.0"
     "@floating-ui/react": "npm:^0.27.19"
+    "@types/leaflet": "npm:^1.9.21"
     "@types/react": "npm:^19.2.17"
     "@types/react-dom": "npm:^19.2.3"
     "@vitejs/plugin-react": "npm:^6.0.2"
@@ -4226,6 +4250,7 @@ __metadata:
     classnames: "npm:^2.5.1"
     date-fns: "npm:^4.4.0"
     eslint: "npm:^10.5.0"
+    leaflet: "npm:^1.9.4"
     lucide-react: "npm:^1.18.0"
     playwright: "npm:^1.60.0"
     prettier: "npm:^3.8.4"


### PR DESCRIPTION
New **Sade** tab: a Leaflet map centred on the saved location with pinch-zoom/pan, an animated timeline, and a recenter button.

## Backend (`radar` module)
- `GET /api/radar/frames` — last-hour observed radar frames, derived from FMI WMS GetCapabilities (5-min steps).
- `GET /api/radar/wms` — transparent proxy for FMI WMS `GetMap` tiles (single fixed upstream, streams bytes).
- `GET /api/radar/forecast` — FMI HARMONIE precipitation forecast: fetches the EPSG:4326 GRIB2 grid, decodes it with the `grib` crate (`default-features = false`, **no native C deps**), reads grid geometry straight from the GDS (no PROJ), orients north-up, **block-max** downsamples, converts **metres→mm**, returns a compact JSON grid. Retries transient FMI connection drops; cached 30 min.

## Frontend (`RainMap`, lazy-loaded)
- Observed WMS frames + forecast **heat overlays** (canvas colour ramp) merged into **one timeline**: play/pause, frame slider, a **"now" divider**, long-press-swipe scrub, relative-time labels (`−30 min` → `nyt` → `+5 h`), and a precipitation legend.
- Pinch-zoom + pan native; CARTO base tiles swap with the light/dark theme.

## Notes
- FMI WMS/WFS need no API key. New settings `FMI_WMS_BASE_URL` / `FMI_DOWNLOAD_BASE_URL` default to the public endpoints.
- Forecast covers southern Finland (~500×380 km) centred on the saved location; whole-Finland would need tiling (single lat/lon overlay misregisters over a tall span).
- Forecast magnitudes cross-validated against FMI's own WFS point forecast.

## Test plan
- [x] `cargo test` — 20 unit + 18 integration pass (incl. GRIB orientation/resampling)
- [x] `yarn validate` (typecheck + lint + format) clean; `yarn build` succeeds
- [x] Endpoints verified live against FMI (frames, WMS tile, forecast grid)