### PR TITLE
fix(radar): decode FMI precipitation as a rate, not metres of water

### DIFF
--- a/backend/src/radar/forecast.rs
+++ b/backend/src/radar/forecast.rs
@@ -7,18 +7,22 @@ use super::models::{ForecastFrame, PrecipForecast};
 
 /// FMI HARMONIE Scandinavia surface producer (hourly precipitation forecast).
 const PRODUCER: &str = "harmonie_scandinavia_surface";
-/// Half-extent of the requested area around the location, in degrees. Sized to
-/// cover southern Finland (centred on the saved location). Whole-Finland would
-/// need tiling — a single lat/lon overlay misregisters over a tall span.
-const HALF_LON: f64 = 4.5;
-const HALF_LAT: f64 = 1.7;
-/// Cap on the resampled grid's longest side. High enough to keep ~native
-/// (~2.5 km) detail across the southern-Finland box; values are rounded to
-/// 0.1 mm so the payload stays modest.
+/// Half-extent of the requested area around the location, in degrees. Covers the
+/// default zoom-8 view plus moderate panning, and is deliberately small enough
+/// that the ~0.0225° native grid (196×107 cells here) stays under
+/// `MAX_GRID_SIDE` and ships undownsampled. A wider box only bought coverage the
+/// map never shows, at the cost of resampling the visible part to mush.
+const HALF_LON: f64 = 2.2;
+const HALF_LAT: f64 = 1.2;
+/// Cap on the resampled grid's longest side — a safety valve for a larger or
+/// finer grid than the box above implies; values are rounded to 0.1 mm so the
+/// payload stays modest either way.
 const MAX_GRID_SIDE: usize = 400;
-/// FMI's GRIB `Precipitation1h` is in metres of water; the rest of the app
-/// (and FMI's own WFS) speaks millimetres.
-const MM_PER_METRE: f32 = 1000.0;
+/// FMI encodes `Precipitation1h` as GRIB2 parameter 0-1-7 (precipitation rate,
+/// kg m⁻² s⁻¹ ≡ mm/s) — *not* metres of water — so mm/h is the rate × 3600. The
+/// underlying field is quantised to 0.1 mm/h, which is why rounding the result to
+/// 0.1 below loses nothing.
+const SECONDS_PER_HOUR: f32 = 3600.0;
 
 type BoxErr = Box<dyn std::error::Error + Send + Sync>;
 
@@ -133,9 +137,7 @@ async fn fetch_once(
                         }
                     }
                 }
-                // FMI's GRIB encodes precipitation in metres; convert to mm and
-                // round to 0.1 mm (finer than the colour bins need, compact JSON).
-                let v = (peak * MM_PER_METRE * 10.0).round() / 10.0;
+                let v = to_mm_per_hour(peak);
                 max = max.max(v);
                 values.push(v);
             }
@@ -183,6 +185,12 @@ fn sample(raw: &[f32], g: &GridGeom, row_from_north: usize, col_from_west: usize
         .filter(|v| v.is_finite())
         .map(|v| v.max(0.0))
         .unwrap_or(0.0)
+}
+
+/// GRIB precipitation rate (mm/s) → mm/h, rounded to 0.1 mm — the quantisation
+/// of the source field, so this is lossless and keeps the JSON compact.
+fn to_mm_per_hour(rate: f32) -> f32 {
+    (rate * SECONDS_PER_HOUR * 10.0).round() / 10.0
 }
 
 fn resampled_dims(ni: usize, nj: usize) -> (usize, usize, usize) {
@@ -247,9 +255,29 @@ fn signed_micro(b: &[u8], o: usize) -> Option<f64> {
 mod tests {
     use super::*;
 
+    /// The field is a rate in mm/s, so mm/h is ×3600. Values below are real
+    /// decoded GRIB samples: FMI's own point forecast reported 0.1 mm for the
+    /// cell that decodes to 2.777_78e-5. Treating them as metres (×1000) rounds
+    /// light rain away to nothing.
+    #[test]
+    fn converts_rate_to_mm_per_hour() {
+        assert_eq!(to_mm_per_hour(2.777_78e-5), 0.1);
+        assert_eq!(to_mm_per_hour(7.222_22e-4), 2.6);
+        assert_eq!(to_mm_per_hour(0.0), 0.0);
+    }
+
     #[test]
     fn resample_keeps_small_grids_intact() {
         assert_eq!(resampled_dims(89, 45), (89, 45, 1));
+    }
+
+    /// The `HALF_LON`/`HALF_LAT` box is sized so FMI's native ~0.0225° grid ships
+    /// undownsampled; widening it again would silently blur the overlay.
+    #[test]
+    fn resample_keeps_the_requested_box_at_native_resolution() {
+        let ni = (2.0 * HALF_LON / 0.0225).round() as usize + 1;
+        let nj = (2.0 * HALF_LAT / 0.0225).round() as usize + 1;
+        assert_eq!(resampled_dims(ni, nj), (ni, nj, 1));
     }
 
     #[test]

--- a/backend/src/radar/handlers.rs
+++ b/backend/src/radar/handlers.rs
@@ -119,33 +119,92 @@ pub async fn frames(
 /// layer points here; we forward the query string verbatim to a single fixed
 /// upstream (no open proxy) and stream the image bytes back. Tiles are cached
 /// by the browser/Leaflet, so no server-side tile cache is needed.
+///
+/// The frontend hands FMI its own colour map through `SLD_BODY` so the observed
+/// and forecast halves of the timeline share one ramp. If FMI ever rejects that —
+/// dynamic styling turned off, or a colour map it dislikes — we retry once
+/// without it: the radar then renders in FMI's palette, which is worse than
+/// halo's but far better than an empty map.
 pub async fn wms(state: web::Data<Arc<AppState>>, req: HttpRequest) -> HttpResponse {
-    let url = format!("{}?{}", state.settings.fmi_wms_base_url, req.query_string());
-
-    match state.http_client.get(&url).send().await {
-        Ok(resp) => {
-            let status =
-                StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
-            let content_type = resp
-                .headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("image/png")
-                .to_string();
-            match resp.bytes().await {
-                Ok(bytes) => HttpResponse::build(status)
-                    .insert_header(("Cache-Control", "public, max-age=300"))
-                    .content_type(content_type)
-                    .body(bytes),
-                Err(e) => {
-                    tracing::error!("Failed to read radar tile body: {e}");
-                    HttpResponse::BadGateway().finish()
-                }
-            }
+    let query = req.query_string();
+    if let Some(tile) = fetch_tile(&state, query).await {
+        return tile;
+    }
+    if let Some(plain) = without_sld_body(query) {
+        tracing::warn!("radar tile rejected with SLD_BODY; retrying with FMI's own style");
+        if let Some(tile) = fetch_tile(&state, &plain).await {
+            return tile;
         }
+    }
+    HttpResponse::BadGateway().finish()
+}
+
+/// `Some` only when the upstream really returned an image. A WMS `ServiceException`
+/// arrives as XML — sometimes with a 200 — so the content type is what decides.
+async fn fetch_tile(state: &AppState, query: &str) -> Option<HttpResponse> {
+    let url = format!("{}?{}", state.settings.fmi_wms_base_url, query);
+    let resp = match state.http_client.get(&url).send().await {
+        Ok(resp) => resp,
         Err(e) => {
             tracing::error!("Failed to proxy radar tile: {e}");
-            HttpResponse::BadGateway().finish()
+            return None;
         }
+    };
+    let status = StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("image/png")
+        .to_string();
+    if !status.is_success() || !content_type.starts_with("image/") {
+        tracing::error!("radar tile upstream returned {status} ({content_type})");
+        return None;
+    }
+    match resp.bytes().await {
+        Ok(bytes) => Some(
+            HttpResponse::build(status)
+                .insert_header(("Cache-Control", "public, max-age=300"))
+                .content_type(content_type)
+                .body(bytes),
+        ),
+        Err(e) => {
+            tracing::error!("Failed to read radar tile body: {e}");
+            None
+        }
+    }
+}
+
+/// Strip `sld_body`/`sld` from a query string. `None` when neither was there —
+/// i.e. there is nothing to retry differently.
+fn without_sld_body(query: &str) -> Option<String> {
+    let mut stripped = false;
+    let kept: Vec<&str> = query
+        .split('&')
+        .filter(|pair| {
+            let key = pair.split('=').next().unwrap_or_default();
+            let drop = key.eq_ignore_ascii_case("sld_body") || key.eq_ignore_ascii_case("sld");
+            stripped |= drop;
+            !drop
+        })
+        .collect();
+    stripped.then(|| kept.join("&"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn without_sld_body_drops_only_the_style_param() {
+        assert_eq!(
+            without_sld_body("layers=Radar:x&SLD_BODY=%3Csld%2F%3E&time=now").as_deref(),
+            Some("layers=Radar:x&time=now"),
+        );
+    }
+
+    #[test]
+    fn without_sld_body_is_none_when_unstyled() {
+        assert_eq!(without_sld_body("layers=Radar:x&time=now"), None);
     }
 }

--- a/backend/src/radar/models.rs
+++ b/backend/src/radar/models.rs
@@ -1,8 +1,12 @@
 use serde::Serialize;
 
-/// The default FMI radar layer: nationwide reflectivity composite (dBZ),
-/// the classic rain-radar look. Updated every 5 minutes.
-pub const DEFAULT_LAYER: &str = "Radar:suomi_dbz_eureffin";
+/// The default FMI radar layer: nationwide rain *rate* (`rr`) composite, updated
+/// every 5 minutes. Chosen over the reflectivity composite
+/// (`Radar:suomi_dbz_eureffin`) because its band is mm/h × 100 — the same unit as
+/// the HARMONIE forecast overlay — so one legend and one colour ramp describe the
+/// whole timeline. The frontend restyles these tiles with its own ramp via
+/// `SLD_BODY`; dBZ could only ever be labelled qualitatively.
+pub const DEFAULT_LAYER: &str = "Radar:suomi_rr_eureffin";
 
 /// Animation frames for the rain radar. `times` is ascending (oldest first),
 /// formatted as the ISO8601 instants FMI's WMS `time` dimension accepts.

--- a/frontend/src/components/RainMap.tsx
+++ b/frontend/src/components/RainMap.tsx
@@ -36,8 +36,11 @@ type Frame = {
 const FRAME_COUNT = 12; // observed radar frames (5-min steps → last hour)
 const FORECAST_HOURS = 12; // forecast frames (hourly)
 const DEFAULT_ZOOM = 8;
-const RADAR_OPACITY = 0.75;
-const FORECAST_OPACITY = 0.6;
+// One opacity for both halves of the timeline: the observed tiles now carry the
+// same ramp and the same per-pixel alpha as the forecast canvas, so anything else
+// would make the palette jump as you scrub past "now".
+const OVERLAY_OPACITY = 0.6;
+const PRECIP_ALPHA = 185; // 0–255, applied by both the canvas and the WMS SLD
 const PLAY_MS = 450; // per-frame while playing
 const HOLD_MS = 1100; // linger on the last frame before looping
 const LONG_PRESS_MS = 300; // hold before map-swipe scrubbing engages
@@ -45,43 +48,93 @@ const PAN_THRESHOLD = 10; // px of movement that counts as a pan, not a press
 const PX_PER_FRAME = 26; // swipe sensitivity once scrubbing
 
 // Precipitation colour ramp (mm/h → RGB). Shared by the heat overlay and legend.
+// Thresholds are tuned to Finnish rain rates — the bulk of what FMI forecasts is
+// 0.1–5 mm/h, so the ramp has to resolve that band rather than spend its blues on
+// it; heavier rates are rare enough to compress into the top stops.
 const PRECIP_STOPS: { v: number; c: [number, number, number] }[] = [
   { v: 0.1, c: [150, 210, 255] },
-  { v: 0.5, c: [90, 170, 245] },
-  { v: 1, c: [50, 120, 230] },
-  { v: 2, c: [40, 80, 200] },
-  { v: 4, c: [60, 180, 90] },
-  { v: 7, c: [220, 205, 50] },
-  { v: 12, c: [240, 140, 30] },
-  { v: 20, c: [225, 45, 45] },
-  { v: 40, c: [170, 0, 110] },
+  { v: 0.3, c: [90, 170, 245] },
+  { v: 0.6, c: [50, 120, 230] },
+  { v: 1, c: [40, 80, 200] },
+  { v: 2, c: [60, 180, 90] },
+  { v: 4, c: [220, 205, 50] },
+  { v: 8, c: [240, 140, 30] },
+  { v: 15, c: [225, 45, 45] },
+  { v: 30, c: [170, 0, 110] },
 ];
 
 const precipColor = (v: number): [number, number, number, number] => {
-  if (!(v >= 0.1)) return [0, 0, 0, 0];
+  if (!(v >= PRECIP_STOPS[0].v)) return [0, 0, 0, 0];
   let c = PRECIP_STOPS[0].c;
   for (const s of PRECIP_STOPS) if (v >= s.v) c = s.c;
-  return [c[0], c[1], c[2], 185];
+  return [c[0], c[1], c[2], PRECIP_ALPHA];
 };
 
-/** Paint one forecast grid into a canvas and wrap it as a geo-placed overlay. */
+const hex = ([r, g, b]: [number, number, number]) =>
+  `#${[r, g, b].map((n) => n.toString(16).padStart(2, "0")).join("")}`;
+
+/**
+ * FMI's WMS colours the observed radar server-side, so the only way to get halo's
+ * ramp onto those frames is to hand GeoServer our own colour map — otherwise the
+ * timeline switches palettes at "now" and the legend describes only half of it.
+ *
+ * The `rr` layer's band is mm/h × 100, matching the forecast overlay's unit.
+ * `type="intervals"` reads each quantity as that interval's *upper* bound, so
+ * entry N carries stop N−1's colour: a leading transparent entry cuts everything
+ * below the first stop, and a wide-open final entry catches the extremes.
+ */
+const buildRadarSld = (layer: string) => {
+  const band = (mm: number) => Math.round(mm * 100);
+  const alpha = (PRECIP_ALPHA / 255).toFixed(3);
+  const entries = [
+    `<ColorMapEntry color="#000000" opacity="0" quantity="${band(PRECIP_STOPS[0].v)}"/>`,
+    ...PRECIP_STOPS.map((s, i) => {
+      const upper = PRECIP_STOPS[i + 1]?.v ?? s.v * 1000;
+      return `<ColorMapEntry color="${hex(s.c)}" opacity="${alpha}" quantity="${band(upper)}"/>`;
+    }),
+  ].join("");
+  return `<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" version="1.0.0"><NamedLayer><Name>${layer}</Name><UserStyle><FeatureTypeStyle><Rule><RasterSymbolizer><ColorMap type="intervals">${entries}</ColorMap></RasterSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer></StyledLayerDescriptor>`;
+};
+
+// Web Mercator's y for a latitude, in the projection's natural units — only the
+// ratio between two y values is used below, so the scale factor cancels out.
+const mercY = (lat: number) => Math.log(Math.tan(Math.PI / 4 + (lat * Math.PI) / 360));
+const invMercY = (y: number) => ((Math.atan(Math.exp(y)) * 2 - Math.PI / 2) * 180) / Math.PI;
+
+/**
+ * Paint one forecast grid into a canvas and wrap it as a geo-placed overlay.
+ *
+ * `L.imageOverlay` stretches the image linearly in Web Mercator, but the grid is
+ * regular in *latitude* — so the rows are resampled into Mercator space here.
+ * Skipping that lands the field a few km too far north mid-box (≈2.6 km over the
+ * current bbox, about one grid cell). Columns stay 1:1: longitude is linear in
+ * Mercator.
+ */
 const buildForecastOverlay = (fc: PrecipForecast, frame: ForecastFrame): L.ImageOverlay => {
   const { cols, rows, bbox } = fc;
+  const [south, west, north, east] = bbox;
   const canvas = document.createElement("canvas");
   canvas.width = cols;
   canvas.height = rows;
   const ctx = canvas.getContext("2d")!;
   const img = ctx.createImageData(cols, rows);
-  for (let p = 0; p < cols * rows; p++) {
-    const [r, g, b, a] = precipColor(frame.values[p]);
-    const o = p * 4;
-    img.data[o] = r;
-    img.data[o + 1] = g;
-    img.data[o + 2] = b;
-    img.data[o + 3] = a;
+  const lastRow = Math.max(1, rows - 1);
+  const yNorth = mercY(north);
+  const ySouth = mercY(south);
+  const dLat = (north - south) / lastRow;
+  for (let y = 0; y < rows; y++) {
+    const lat = invMercY(yNorth + (ySouth - yNorth) * (y / lastRow));
+    const src = Math.min(rows - 1, Math.max(0, Math.round((north - lat) / dLat)));
+    for (let x = 0; x < cols; x++) {
+      const [r, g, b, a] = precipColor(frame.values[src * cols + x]);
+      const o = (y * cols + x) * 4;
+      img.data[o] = r;
+      img.data[o + 1] = g;
+      img.data[o + 2] = b;
+      img.data[o + 3] = a;
+    }
   }
   ctx.putImageData(img, 0, 0);
-  const [south, west, north, east] = bbox;
   return L.imageOverlay(
     canvas.toDataURL(),
     [
@@ -178,6 +231,39 @@ const RainMap = ({ className }: { className?: string }) => {
     baseRef.current = base;
   }, [theme.mode, ready]);
 
+  // --- saved-location marker, so the centre point stays findable under the
+  // overlay. Accent orange: the precipitation ramp is all blues/greens/reds, so
+  // the marker can't be mistaken for rain. Vector layers default into
+  // `overlayPane` alongside the forecast images — `markerPane` keeps it on top
+  // (Leaflet spins up a per-pane renderer for a non-default `pane`).
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !ready || !location) return;
+    const at: L.LatLngExpression = [location.lat, location.lon];
+    const accent = theme.colors.activity.on;
+    const marks = [
+      L.circleMarker(at, {
+        pane: "markerPane",
+        radius: 9,
+        color: accent,
+        weight: 2,
+        fill: false,
+        interactive: false,
+      }),
+      L.circleMarker(at, {
+        pane: "markerPane",
+        radius: 3.5,
+        color: theme.colors.background.main,
+        weight: 1.5,
+        fillColor: accent,
+        fillOpacity: 1,
+        interactive: false,
+      }),
+    ];
+    marks.forEach((m) => m.addTo(map));
+    return () => marks.forEach((m) => map.removeLayer(m));
+  }, [location, ready, theme.colors.activity.on, theme.colors.background.main]);
+
   // --- build the unified layer stack: observed WMS tiles + forecast heat ---
   useEffect(() => {
     const map = mapRef.current;
@@ -186,6 +272,8 @@ const RainMap = ({ className }: { className?: string }) => {
 
     const built: Frame[] = [];
     if (obsData) {
+      // Same colour map for all 12 frames, so build it once.
+      const sldBody = buildRadarSld(obsData.layer);
       for (const time of obsData.times) {
         const layer = L.tileLayer
           .wms(api("/api/radar/wms"), {
@@ -195,13 +283,14 @@ const RainMap = ({ className }: { className?: string }) => {
             version: "1.3.0",
             opacity: 0,
             time,
+            sld_body: sldBody,
           } as unknown as L.WMSOptions)
           .addTo(map);
         built.push({
           kind: "observed",
           time,
           layer,
-          baseOpacity: RADAR_OPACITY,
+          baseOpacity: OVERLAY_OPACITY,
         });
       }
     }
@@ -212,7 +301,7 @@ const RainMap = ({ className }: { className?: string }) => {
           kind: "forecast",
           time: frame.time,
           layer,
-          baseOpacity: FORECAST_OPACITY,
+          baseOpacity: OVERLAY_OPACITY,
         });
       }
     }
@@ -379,8 +468,10 @@ const RainMap = ({ className }: { className?: string }) => {
     >
       <div ref={containerRef} css={{ position: "absolute", inset: 0, zIndex: 0 }} />
 
-      {/* precipitation legend (top-centre, clear of the left zoom + right recenter) */}
-      {fcData && (
+      {/* precipitation legend (top-centre, clear of the left zoom + right recenter).
+          Both halves of the timeline are mm/h in this ramp, so it stays valid
+          whichever half has loaded. */}
+      {(obsData || fcData) && (
         <div
           css={{
             position: "absolute",


### PR DESCRIPTION
The rain tab's forecast frames rendered essentially blank while FMI's own app
showed a clear precipitation field for the same hour.

## Root cause

`Precipitation1h` is GRIB2 parameter **0-1-7 — precipitation rate in
kg m⁻² s⁻¹ (mm/s)**, not metres of water. The decoder multiplied by 1000 instead
of 3600, so every value came out 3.6× low, was rounded to 0.1 mm, and then had
anything below the ramp's 0.1 threshold dropped. Net effect: only cells above
~0.36 mm/h drew at all, and everything up to 3.6 mm/h drew in the palest blue.

It also explains why the "ei sadetta ennusteessa" hint never appeared on those
frames — `frame.max` was non-zero (0.72 for the reference hour), so the frame
wasn't classified as dry even though it painted almost nothing.

## Verification

Checked against FMI's own point-forecast API rather than only unit tests:

- The Tampere cell decodes to `2.7778e-5`; `opendata.fmi.fi/timeseries` reports
  `0.1 mm` for that hour. `× 3600 = 0.1` ✔, `× 1000 = 0.028` ✘. Every decoded
  value is an exact multiple of `0.1/3600`.
- 10 of 12 forecast hours at the saved location now match `Precipitation1h`
  exactly; the two outliers differ by 0.1 mm, which is nearest-cell pick vs FMI's
  bilinear interpolation.
- 6 off-centre probes match exactly. Worth doing because Tampere sits mid-box,
  where a flipped-rows bug would be invisible — these confirm orientation too.
- The reference frame now covers ~78% of the visible map in structured
  0.1–1 mm/h precipitation, peaking at 1.4 mm/h.

For the observed/forecast ramp unification, tested through halo's own proxy: the
styled tile returns 9/9 halo ramp colours with zero foreign colours; the unstyled
tile returns FMI's palette instead (proving the SLD is what's doing the work);
and a deliberately broken SLD falls back to a tile byte-identical to the
unstyled one.

`cargo test` 24 + 18 green (4 new radar tests), `yarn validate` clean.

## Also in here

- **Sharper grid.** The old 9.0° × 3.4° box produced 401 native cells, tripping
  `MAX_GRID_SIDE` and halving the grid to 201×76 — of which only ~22% of the
  width was ever on screen at the default zoom. Now 4.4° × 2.4°, shipping at
  native ~2.5 km resolution (196×107, stride 1).
- **Retuned ramp** to 0.1–30 mm/h; Finnish rain is mostly 0.1–5 mm/h, which the
  old 0.1–40 ramp spent entirely on blues.
- **Mercator row placement.** `imageOverlay` stretches linearly in the
  projection, but the grid is regular in latitude, so rows landed ~2.6 km too far
  north mid-box. Measured placement error drops 2.57 km → 1.26 km, the residual
  being half-cell quantisation.
- **One ramp across the whole timeline.** Observed frames move from
  `Radar:suomi_dbz_eureffin` to `Radar:suomi_rr_eureffin` (rain rate, band =
  mm/h × 100) and are restyled with halo's own ramp via `SLD_BODY`, generated
  from `PRECIP_STOPS`. Previously the palette jumped as you scrubbed past "now"
  and the legend described only half the timeline — dBZ can only be labelled
  qualitatively, and FMI's own style names its bins
  *kohtalainen/sakea/hyvin sakea*. Retuning `PRECIP_STOPS` later now updates both
  halves automatically.
- **Proxy fallback.** If a tile carrying `SLD_BODY` comes back as a WMS
  `ServiceException` (XML, sometimes with a 200), the proxy retries once without
  it, so the radar degrades to FMI's palette rather than an empty map.
- **Location marker** — accent ring + dot at the saved coordinates, in
  `markerPane` so frames never paint over it and non-interactive so it doesn't
  eat the long-press scrub gesture.

## Worth knowing

- **halo's forecast will still read lighter than FMI's app at short lead times.**
  That view is a radar extrapolation nowcast; this is the HARMONIE model, and
  HARMONIE genuinely forecast only 0.1–0.4 mm over Tampere for the hour in
  question — FMI's human-edited `pal_skandinavia` agrees. FMI's open WMS
  publishes no nowcast layer (all 116 `Radar:*` layers are observed products), so
  there is nothing to switch to. That gap is meteorology, not code.
- **`rr` shows slightly less fine texture than dBZ.** Reflectivity picks up faint
  echoes the rain-rate product doesn't, and halo's ramp starts at 0.1 mm/h where
  FMI's `rr` style starts at 0.07 — so the very lightest returns now read as dry.
  That's the cost of both halves being the same quantity.
- **Observed frames are slightly lighter than before**, since `RADAR_OPACITY`
  (0.75) and `FORECAST_OPACITY` (0.6) collapsed into one `OVERLAY_OPACITY`;
  differing alphas would have re-introduced a jump at "now".
- **The SLD depends on FMI keeping dynamic styling enabled.** The fallback covers
  them turning it off — if the observed frames ever show FMI's louder cyan/green
  palette, that's it firing (`retrying with FMI's own style` in the log).
