### PR TITLE
fix(radar): stop serving an expired forecast when FMI is down

### DIFF
--- a/backend/src/cache.rs
+++ b/backend/src/cache.rs
@@ -32,12 +32,15 @@ impl<T: Clone> Cache<T> {
         })
     }
 
-    /// Returns cached data even if expired (for fallback on error), only if key matches.
-    pub async fn get_stale(&self, key: &str) -> Option<T> {
+    /// Cached data past its TTL, for use as a fallback when the upstream fails.
+    /// Matches on key like [`Cache::get`], but `max_age` bounds how stale is
+    /// still useful: without it a dead upstream pins the last good response
+    /// forever, and the caller has no way to tell it apart from a fresh one.
+    pub async fn get_stale(&self, key: &str, max_age: Duration) -> Option<T> {
         let guard = self.inner.read().await;
         guard
             .as_ref()
-            .filter(|entry| entry.key == key)
+            .filter(|entry| entry.key == key && entry.created_at.elapsed() < max_age)
             .map(|entry| entry.data.clone())
     }
 
@@ -59,5 +62,36 @@ impl<T: Clone> Cache<T> {
 
     pub async fn has_data(&self) -> bool {
         self.inner.read().await.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HOUR: Duration = Duration::from_secs(3600);
+
+    #[tokio::test]
+    async fn get_stale_serves_a_recent_entry_past_its_ttl() {
+        let cache = Cache::new(Duration::ZERO); // already expired for `get`
+        cache.set("k".into(), 42).await;
+        assert_eq!(cache.get("k").await, None);
+        assert_eq!(cache.get_stale("k", HOUR).await, Some(42));
+    }
+
+    /// The bound is the point of the parameter: an upstream that has been down
+    /// long enough must stop resurrecting its last good response.
+    #[tokio::test]
+    async fn get_stale_refuses_an_entry_older_than_max_age() {
+        let cache = Cache::new(HOUR);
+        cache.set("k".into(), 42).await;
+        assert_eq!(cache.get_stale("k", Duration::ZERO).await, None);
+    }
+
+    #[tokio::test]
+    async fn get_stale_still_matches_on_key() {
+        let cache = Cache::new(HOUR);
+        cache.set("k".into(), 42).await;
+        assert_eq!(cache.get_stale("other", HOUR).await, None);
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -194,6 +194,14 @@ pub fn create_app(
         .route("/status", web::get().to(status))
         .service(
             web::scope("/api")
+                // These payloads are all live state, and none of them carry a
+                // validator. iOS Safari heuristically caches an unlabelled GET,
+                // which leaves an installed PWA rendering last night's data
+                // against a backend that has long since moved on. `DefaultHeaders`
+                // only fills in a header that is absent, so the radar tile route's
+                // own `public, max-age=300` still stands — tiles stay cacheable,
+                // JSON does not.
+                .wrap(middleware::DefaultHeaders::new().add(("Cache-Control", "no-store")))
                 .service(
                     web::scope("/history")
                         .route("/sensors", web::get().to(sensor_history))

--- a/backend/src/radar/handlers.rs
+++ b/backend/src/radar/handlers.rs
@@ -1,10 +1,22 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use actix_web::{http::StatusCode, web, HttpRequest, HttpResponse};
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
-use super::models::DEFAULT_LAYER;
+use super::models::{PrecipForecast, DEFAULT_LAYER};
 use crate::AppState;
+
+/// Upper bound on the forecast we will fall back to when FMI is unreachable.
+/// Frames are dropped individually as they age out (see [`future_frames`]), so
+/// this is only a backstop against handing out a grid whose remaining frames
+/// come from a model run too old to trust.
+const FORECAST_MAX_STALE: Duration = Duration::from_secs(3 * 3600);
+
+/// Frame timestamps go straight into the WMS `time` dimension, and FMI keeps
+/// only a short window of radar composites online — an older list would just
+/// render as empty tiles.
+const FRAMES_MAX_STALE: Duration = Duration::from_secs(3600);
 
 #[derive(Debug, Deserialize, utoipa::IntoParams)]
 pub struct ForecastQuery {
@@ -32,9 +44,16 @@ pub async fn forecast(
     let hours = query.hours.unwrap_or(12).clamp(1, 24);
     // Round the location into the cache key so small map nudges reuse the grid.
     let key = format!("{:.2},{:.2}:{hours}", query.lat, query.lon);
+    let now = Utc::now();
 
+    // Every exit trims against the *current* clock, and the cache keeps the
+    // untrimmed grid — the same entry is served to a request an hour later
+    // minus one more frame, rather than being frozen at whatever "future"
+    // meant when it was fetched.
     if let Some(cached) = state.precip_forecast_cache.get(&key).await {
-        return HttpResponse::Ok().json(cached);
+        if let Some(fresh) = future_frames(cached, now) {
+            return HttpResponse::Ok().json(fresh);
+        }
     }
 
     match super::forecast::fetch_forecast(
@@ -48,18 +67,52 @@ pub async fn forecast(
     {
         Ok(forecast) => {
             state.precip_forecast_cache.set(key, forecast.clone()).await;
-            HttpResponse::Ok().json(forecast)
+            match future_frames(forecast, now) {
+                Some(fresh) => HttpResponse::Ok().json(fresh),
+                None => no_forecast(),
+            }
         }
         Err(e) => {
             tracing::error!("Failed to fetch precip forecast: {e}");
-            if let Some(stale) = state.precip_forecast_cache.get_stale(&key).await {
-                HttpResponse::Ok().json(stale)
-            } else {
-                HttpResponse::BadGateway()
-                    .json(serde_json::json!({"error": "No forecast available"}))
+            match state
+                .precip_forecast_cache
+                .get_stale(&key, FORECAST_MAX_STALE)
+                .await
+                .and_then(|stale| future_frames(stale, now))
+            {
+                Some(stale) => {
+                    tracing::warn!("Returning stale precip forecast");
+                    HttpResponse::Ok().json(stale)
+                }
+                None => no_forecast(),
             }
         }
     }
+}
+
+fn no_forecast() -> HttpResponse {
+    HttpResponse::BadGateway().json(serde_json::json!({"error": "No forecast available"}))
+}
+
+/// Keep only the frames whose valid time is still ahead.
+///
+/// Frames carry absolute times, so a cached grid ages out frame by frame rather
+/// than all at once: at 22:30 a 20:00 model run is still a real forecast for
+/// 23:00 onward. Without this, a cache entry that outlives its own horizon —
+/// which is exactly what happens when FMI is down overnight — gets rendered as
+/// "+1 h … +12 h" and shows last night's rain as tomorrow's.
+///
+/// `None` when nothing is left, so the caller can 502 instead of shipping an
+/// empty timeline.
+fn future_frames(mut fc: PrecipForecast, now: DateTime<Utc>) -> Option<PrecipForecast> {
+    // An unparseable time is kept: it would mean the format changed and this
+    // was not updated, and silently emptying the forecast is the worse failure.
+    fc.frames
+        .retain(|f| match DateTime::parse_from_rfc3339(&f.time) {
+            Ok(t) => t.with_timezone(&Utc) > now,
+            Err(_) => true,
+        });
+    (!fc.frames.is_empty()).then_some(fc)
 }
 
 #[derive(Debug, Deserialize, utoipa::IntoParams)]
@@ -105,7 +158,11 @@ pub async fn frames(
         }
         Err(e) => {
             tracing::error!("Failed to fetch radar frames: {e}");
-            if let Some(stale) = state.radar_frames_cache.get_stale(&key).await {
+            if let Some(stale) = state
+                .radar_frames_cache
+                .get_stale(&key, FRAMES_MAX_STALE)
+                .await
+            {
                 HttpResponse::Ok().json(stale)
             } else {
                 HttpResponse::BadGateway()
@@ -194,6 +251,60 @@ fn without_sld_body(query: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::radar::models::ForecastFrame;
+
+    fn forecast(times: &[&str]) -> PrecipForecast {
+        PrecipForecast {
+            bbox: [59.0, 22.0, 61.0, 26.0],
+            cols: 1,
+            rows: 1,
+            unit: "mm/h".into(),
+            frames: times
+                .iter()
+                .map(|t| ForecastFrame {
+                    time: (*t).into(),
+                    max: 1.0,
+                    values: vec![1.0],
+                })
+                .collect(),
+        }
+    }
+
+    fn at(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn future_frames_keeps_an_all_future_forecast_intact() {
+        let fc = forecast(&["2026-06-22T19:00:00Z", "2026-06-22T20:00:00Z"]);
+        let kept = future_frames(fc, at("2026-06-22T18:10:00Z")).unwrap();
+        assert_eq!(kept.frames.len(), 2);
+    }
+
+    /// The overnight case: an evening model run reached from the morning has
+    /// nothing left to say, and must not be served as "+1 h".
+    #[test]
+    fn future_frames_rejects_a_wholly_elapsed_forecast() {
+        let fc = forecast(&["2026-06-22T19:00:00Z", "2026-06-22T20:00:00Z"]);
+        assert!(future_frames(fc, at("2026-06-23T07:00:00Z")).is_none());
+    }
+
+    #[test]
+    fn future_frames_drops_only_the_elapsed_head() {
+        let fc = forecast(&[
+            "2026-06-22T19:00:00Z",
+            "2026-06-22T20:00:00Z",
+            "2026-06-22T21:00:00Z",
+        ]);
+        let kept = future_frames(fc, at("2026-06-22T20:30:00Z")).unwrap();
+        assert_eq!(
+            kept.frames
+                .iter()
+                .map(|f| f.time.as_str())
+                .collect::<Vec<_>>(),
+            ["2026-06-22T21:00:00Z"],
+        );
+    }
 
     #[test]
     fn without_sld_body_drops_only_the_style_param() {

--- a/backend/src/solis/handlers.rs
+++ b/backend/src/solis/handlers.rs
@@ -1,10 +1,15 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use actix_web::{web, HttpResponse};
 use serde::Deserialize;
 use utoipa::IntoParams;
 
 use crate::AppState;
+
+/// This is live inverter state — power flows, battery SoC. An hour past the
+/// 5-min TTL is already generous; beyond that the numbers are fiction and a
+/// 502 (which the frontend renders as unavailable) is the honest answer.
+const MAX_STALE: Duration = Duration::from_secs(3600);
 
 #[utoipa::path(
     get,
@@ -33,7 +38,7 @@ pub async fn get_data(state: web::Data<Arc<AppState>>) -> HttpResponse {
         }
         Err(e) => {
             tracing::error!("Failed to fetch SolisCloud data: {e}");
-            if let Some(stale) = state.solis_cache.get_stale("station").await {
+            if let Some(stale) = state.solis_cache.get_stale("station", MAX_STALE).await {
                 tracing::warn!("Returning stale SolisCloud data");
                 return HttpResponse::Ok().json(stale);
             }

--- a/backend/src/spot/handlers.rs
+++ b/backend/src/spot/handlers.rs
@@ -1,8 +1,13 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use actix_web::{web, HttpResponse};
 
 use crate::AppState;
+
+/// A spot response is a full day-ahead array, so it stays useful for hours past
+/// the 10-min TTL — but not across midnight, where "today" silently becomes
+/// yesterday's prices.
+const MAX_STALE: Duration = Duration::from_secs(6 * 3600);
 
 #[utoipa::path(
     get,
@@ -24,7 +29,7 @@ pub async fn get_spot(state: web::Data<Arc<AppState>>) -> HttpResponse {
         }
         Err(e) => {
             tracing::error!("Failed to fetch spot prices: {e}");
-            if let Some(stale) = state.spot_cache.get_stale("spot").await {
+            if let Some(stale) = state.spot_cache.get_stale("spot", MAX_STALE).await {
                 tracing::warn!("Returning stale spot prices");
                 return HttpResponse::Ok().json(stale);
             }

--- a/backend/src/weather/handlers.rs
+++ b/backend/src/weather/handlers.rs
@@ -1,10 +1,16 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use actix_web::{web, HttpResponse};
 use serde::Deserialize;
 
 use super::fmi::converter::FmiConverter;
 use crate::AppState;
+
+/// How old a cached observation may be before we stop offering it as a
+/// fallback. Comfortably past the 1 h TTL — a brief upstream wobble should not
+/// blank the dashboard — but short of the point where "current conditions" have
+/// become yesterday's.
+const MAX_STALE: Duration = Duration::from_secs(6 * 3600);
 
 #[derive(Debug, Deserialize)]
 pub struct LocationQuery {
@@ -66,7 +72,7 @@ pub async fn fmi(
 }
 
 async fn fmi_fallback_or_error(state: &AppState, key: &str) -> HttpResponse {
-    if let Some(stale) = state.weather_cache.get_stale(key).await {
+    if let Some(stale) = state.weather_cache.get_stale(key, MAX_STALE).await {
         tracing::warn!("Returning stale cached weather data");
         HttpResponse::Ok().json(stale)
     } else {
@@ -112,7 +118,7 @@ pub async fn tomorrow(
 }
 
 async fn tomorrow_fallback_or_error(state: &AppState, key: &str) -> HttpResponse {
-    if let Some(stale) = state.tomorrow_cache.get_stale(key).await {
+    if let Some(stale) = state.tomorrow_cache.get_stale(key, MAX_STALE).await {
         tracing::warn!("Returning stale cached weather data");
         HttpResponse::Ok().json(stale)
     } else {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,7 +2,12 @@ const API_BASE = import.meta.env.VITE_API_URL ?? "";
 
 export const api = (path: string) => `${API_BASE}${path}`;
 
-export const fetcher = (url: string) => fetch(url).then((res) => res.json());
+// `no-store` on every API read: none of these responses carry a validator, and
+// iOS Safari heuristically caches an unlabelled GET — an installed PWA then
+// keeps serving last night's payload out of its own disk cache no matter how
+// often SWR revalidates. The backend sends `Cache-Control: no-store` too; this
+// is the same belt-and-braces as `useDeployReload`.
+export const fetcher = (url: string) => fetch(url, { cache: "no-store" }).then((res) => res.json());
 
 export class HttpError extends Error {
   status: number;
@@ -14,7 +19,7 @@ export class HttpError extends Error {
 }
 
 export const jsonFetcher = async (url: string) => {
-  const res = await fetch(url);
+  const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) throw new HttpError(res.status);
   return res.json();
 };

--- a/frontend/src/components/RainMap.tsx
+++ b/frontend/src/components/RainMap.tsx
@@ -149,12 +149,19 @@ const RainMap = ({ className }: { className?: string }) => {
   const theme = useTheme();
   const { location } = useLocationSettings();
 
-  const { data: obsData, error: obsError } = useSWR<RadarFrames>(
-    api(`/api/radar/frames?count=${FRAME_COUNT}`),
-    jsonFetcher,
-    { refreshInterval: 60_000, shouldRetryOnError: false },
-  );
-  const { data: fcData, error: fcError } = useSWR<PrecipForecast>(
+  const {
+    data: obsData,
+    error: obsError,
+    mutate: mutateObs,
+  } = useSWR<RadarFrames>(api(`/api/radar/frames?count=${FRAME_COUNT}`), jsonFetcher, {
+    refreshInterval: 60_000,
+    shouldRetryOnError: false,
+  });
+  const {
+    data: fcData,
+    error: fcError,
+    mutate: mutateFc,
+  } = useSWR<PrecipForecast>(
     location
       ? api(`/api/radar/forecast?lat=${location.lat}&lon=${location.lon}&hours=${FORECAST_HOURS}`)
       : null,
@@ -162,6 +169,36 @@ const RainMap = ({ className }: { className?: string }) => {
     // The FMI GRIB fetch can fail transiently (502); retry a few times rather
     // than leaving the timeline stuck at "now" until the next refresh.
     { refreshInterval: 600_000, errorRetryCount: 4, errorRetryInterval: 5_000 },
+  );
+
+  // Cutoff for "still ahead of us". Bumped on wake rather than ticked on a
+  // clock: a per-second tick would rebuild the whole Leaflet layer stack.
+  const [horizon, setHorizon] = useState(() => Date.now());
+
+  // iOS suspends `refreshInterval` timers while backgrounded, so a phone or
+  // panel picked up after a long sleep still holds whatever it had when it went
+  // under. Refetch on wake — same pattern and reason as SpotPrice.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState !== "visible") return;
+      setHorizon(Date.now());
+      void mutateObs();
+      void mutateFc();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [mutateObs, mutateFc]);
+
+  // Forecast frames carry absolute valid times, so the copy held in memory ages
+  // as the device sleeps. Drop what has already happened, so the timeline can't
+  // label an elapsed frame "+1 h" in the gap between waking and the refetch
+  // landing. The backend trims the same way on every response; this is the
+  // client-side half of it.
+  const forecastFrames = useMemo(
+    () => (fcData?.frames ?? []).filter((f) => new Date(f.time).getTime() > horizon),
+    [fcData, horizon],
   );
 
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -177,12 +214,13 @@ const RainMap = ({ className }: { className?: string }) => {
   // with the layers built in the effect below from the same two sources.
   const timeline = useMemo(() => {
     const obs = (obsData?.times ?? []).map((time) => ({ kind: "observed", time }) as const);
-    const fc = (fcData?.frames ?? []).map((f) => ({ kind: "forecast", time: f.time }) as const);
+    const fc = forecastFrames.map((f) => ({ kind: "forecast", time: f.time }) as const);
     return [...obs, ...fc];
-  }, [obsData, fcData]);
+  }, [obsData, forecastFrames]);
 
   const observedCount = obsData?.times.length ?? 0;
   const nowIndex = observedCount - 1;
+  const nowTime = obsData?.times[nowIndex];
   const lastIndex = timeline.length - 1;
 
   // --- map lifecycle (re-created if the location changes) ---
@@ -294,8 +332,8 @@ const RainMap = ({ className }: { className?: string }) => {
         });
       }
     }
-    if (fcData && fcData.frames.length > 0) {
-      for (const frame of fcData.frames) {
+    if (fcData && forecastFrames.length > 0) {
+      for (const frame of forecastFrames) {
         const layer = buildForecastOverlay(fcData, frame).addTo(map);
         built.push({
           kind: "forecast",
@@ -317,7 +355,7 @@ const RainMap = ({ className }: { className?: string }) => {
       built.forEach((f) => map.removeLayer(f.layer));
       framesRef.current = [];
     };
-  }, [obsData, fcData, ready]);
+  }, [obsData, fcData, forecastFrames, ready]);
 
   // --- show only the active frame ---
   useEffect(() => {
@@ -422,11 +460,23 @@ const RainMap = ({ className }: { className?: string }) => {
       relText = `−${back * obsInterval} min`;
     }
   } else if (active?.kind === "forecast") {
-    relText = `+${index - nowIndex} h`;
+    // Measured from the frame's own valid time against the latest observed
+    // frame — the same instant the timeline calls "nyt" — rather than from its
+    // position in the array. A cached grid can have lost its leading hours, and
+    // an index-derived label would then quietly misdate every frame.
+    //
+    // Ceil, not round: "nyt" lands wherever the last radar sweep did (:50, say)
+    // while forecast frames sit on the hour, so the first one is only minutes
+    // out. Rounding would call both 10:00 and 11:00 "+1 h"; ceil counts whole
+    // forecast hours, which is what the label means.
+    const ahead = nowTime
+      ? Math.ceil((new Date(active.time).getTime() - new Date(nowTime).getTime()) / 3_600_000)
+      : index - nowIndex;
+    relText = `+${Math.max(1, ahead)} h`;
     relColor = theme.colors.cool;
   }
   const activeForecastDry =
-    active?.kind === "forecast" && (fcData?.frames[index - observedCount]?.max ?? 0) === 0;
+    active?.kind === "forecast" && (forecastFrames[index - observedCount]?.max ?? 0) === 0;
 
   const legendGradient = PRECIP_STOPS.map(
     (s, i) => `rgb(${s.c[0]},${s.c[1]},${s.c[2]}) ${(i / (PRECIP_STOPS.length - 1)) * 100}%`,


### PR DESCRIPTION
## The bug

Checked the rain view on iOS in the evening; next morning it still showed the evening's forecast. Opening it on a second device returned fresh data, and the iOS device then updated too.

That last part is the tell — the forecast cache is **server-side and shared**, so whichever request first caught FMI healthy repaired it for every client.

`Cache::get_stale` matched on key alone, with **no age bound**. FMI's `opendata/download` drops connections mid-response often enough to exhaust the 3-attempt retry budget (~3 s), and the radar handler then fell back to whatever was cached — overnight, the previous evening's grid. `RainMap` labelled frames by array index, so that grid rendered as "+1 h … +12 h".

The trigger reproduced live while verifying this branch:

```
WARN precip forecast attempt 1 failed: error decoding response body
WARN precip forecast attempt 2 failed: error decoding response body
WARN precip forecast attempt 3 failed: error decoding response body
```

## Changes

**`cache.rs`** — `get_stale(key, max_age)`. All six call sites pass a bound: 3 h for the precip forecast, 1 h for radar frames and Solis live state, 6 h for weather and spot. Generous everywhere but the forecast, so nothing else changes in practice — no endpoint can serve yesterday's data as today's any more.

**`radar/handlers.rs`** — `future_frames()`, applied on every exit (fresh, cache hit, stale fallback). Frames carry absolute times, so a grid ages out frame by frame: at 22:30 a 20:00 run is still a real forecast for 23:00 onward. The cache keeps the untrimmed grid; only the response is trimmed. Nothing left → 502, which the frontend's `errorRetryCount` and the existing "Sadetutka ei juuri nyt saatavilla" hint already handle.

**`lib.rs` + `api.ts`** — `Cache-Control: no-store` on the `/api` scope, mirrored in the fetchers. iOS Safari heuristically caches unlabelled GETs (we already worked around this once in `useDeployReload`). `DefaultHeaders` only fills an absent header, so the WMS tile route keeps its `public, max-age=300`.

**`RainMap.tsx`** — refetch on `visibilitychange` (iOS suspends `refreshInterval` while backgrounded; same pattern as `SpotPrice`), a client-side trim for the gap between waking and the refetch landing, and the "+N h" label derived from each frame's own timestamp rather than its array index.

## Verification

- `cargo test` — 30 unit + 18 smoke, incl. new coverage for the `get_stale` bound and `future_frames` (all-future / all-past / mixed).
- `cargo fmt`, clippy `-D warnings`, `yarn validate` all clean.
- Live: `no-store` on `/api/radar/forecast` and `/api/settings`, `public, max-age=300` still on `/api/radar/wms`; cold cache + unreachable FMI → 502 `{"error":"No forecast available"}`.
- Radar view driven in Chromium: 12 observed (−55 min → nyt) + 12 forecast (+1 h → +12 h), overlay and playback intact.

## Note

`fetch_forecast`'s retry budget is tight (3 attempts, ~3 s) against an upstream whose wobbles last longer. The frontend's `errorRetryCount: 4` over ~20 s covers it, so it's untouched here — worth revisiting separately.